### PR TITLE
글로벌 스타일 정의하기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,22 @@
 import { Routes } from "react-router-dom";
 import { Route } from "react-router-dom";
 import Home from "./routes/Home";
+import { Global, ThemeProvider } from "@emotion/react";
+
+import { theme } from "./assets/theme";
+import GlobalStyle from './assets/GlobalStyle'
+import Style from "./routes/style";
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/">
-        <Route path="" element={<Home />} />
-      </Route>
-    </Routes>
+    <ThemeProvider theme={theme}>
+      <Global styles={GlobalStyle} />
+      <Routes>
+        <Route path="/">
+          <Route path="" element={<Home />} />
+          <Route path="/style" element={<Style />} />
+        </Route>
+      </Routes>
+    </ThemeProvider>
   );
 }

--- a/src/assets/GlobalStyle.tsx
+++ b/src/assets/GlobalStyle.tsx
@@ -1,0 +1,133 @@
+import { css } from "@emotion/react";
+
+const reset = css`
+  @import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css);
+  * {
+    html,
+    body,
+    div,
+    span,
+    applet,
+    object,
+    iframe,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    blockquote,
+    pre,
+    a,
+    abbr,
+    acronym,
+    address,
+    big,
+    cite,
+    code,
+    del,
+    dfn,
+    em,
+    img,
+    ins,
+    kbd,
+    q,
+    s,
+    samp,
+    small,
+    strike,
+    strong,
+    sub,
+    sup,
+    tt,
+    var,
+    b,
+    u,
+    i,
+    center,
+    dl,
+    dt,
+    dd,
+    ol,
+    ul,
+    li,
+    fieldset,
+    form,
+    label,
+    legend,
+    table,
+    caption,
+    tbody,
+    tfoot,
+    thead,
+    tr,
+    th,
+    td,
+    article,
+    aside,
+    canvas,
+    details,
+    embed,
+    figure,
+    figcaption,
+    footer,
+    header,
+    hgroup,
+    menu,
+    nav,
+    output,
+    ruby,
+    section,
+    summary,
+    time,
+    mark,
+    audio,
+    video {
+      margin: 0;
+      padding: 0;
+      border: 0;
+      font-size: 100%;
+      font-family: "Spoqa Han Sans Neo", "sans-serif";
+      vertical-align: baseline;
+    }
+
+    article,
+    aside,
+    details,
+    figcaption,
+    figure,
+    footer,
+    header,
+    hgroup,
+    menu,
+    nav,
+    section {
+      display: block;
+    }
+    body {
+      line-height: 1;
+    }
+    ol,
+    ul {
+      list-style: none;
+    }
+    blockquote,
+    q {
+      quotes: none;
+    }
+    blockquote:before,
+    blockquote:after,
+    q:before,
+    q:after {
+      content: "";
+      content: none;
+    }
+    table {
+      border-collapse: collapse;
+      border-spacing: 0;
+    }
+  }
+`;
+
+export default reset;

--- a/src/assets/emotion.d.ts
+++ b/src/assets/emotion.d.ts
@@ -1,0 +1,10 @@
+import "@emotion/react";
+
+// Theme 타입에 colors 프로퍼티를 추가하여 확장합니다.
+declare module "@emotion/react" {
+  export interface Theme {
+    colors: {
+      [key: string]: string;
+    };
+  }
+}

--- a/src/assets/theme.ts
+++ b/src/assets/theme.ts
@@ -1,0 +1,66 @@
+import "@emotion/react";
+
+declare module "@emotion/react" {
+  export interface Theme {
+    colors: {
+      [key: string]: string;
+    };
+  }
+}
+
+const colors = {
+  // blue가 아닌 primary로 작성돠는게 좋을지 리뷰 부탁드립니다.
+  blue: {
+    "100": "#003371",
+    "90": "#00469C",
+    "80": "#0057C3",
+    "70": "#0064DF",
+    "60": "#006EF5",
+    "50": "#117CFF",
+    "40": "#358FFF",
+    "30": "#5DA6FF",
+    "20": "#90C2FF",
+    "10": "#BEDBFF",
+  },
+  yellow: {
+    "50": "#FFD74E",
+  },
+  neutral: {
+    "100": "#161717",
+    "90": "#212222",
+    "80": "#414242",
+    "70": "#606061",
+    "60": "#747475",
+    "50": "#9D9D9E",
+    "40": "#BCBCBD",
+    "30": "#DFDFE0",
+    "20": "#EDEDEE",
+    "10": "#F4F4F5",
+    "05": "#F9F9FA",
+  },
+  red: {
+    "100": "#740000",
+    "90": "#9C0000",
+    "80": "#C40404",
+    "70": "#E00404",
+    "60": "#EC0404",
+    "50": "#FF1111",
+    "40": "#FF3535",
+    "30": "#FF5D5D",
+    "20": "#FF9090",
+    "10": "#FFBEBE",
+  },
+};
+
+const heading1 = {
+  // heading 1 예시입니다.
+  fontWeight: "bold",
+  fontSize: "28px",
+  lineHeight: "150%",
+  letterSpacing: 0,
+};
+
+export const theme = {
+  colors,
+  heading1,
+};

--- a/src/routes/Style.tsx
+++ b/src/routes/Style.tsx
@@ -1,0 +1,20 @@
+// theme 테스트 라우트입니다.
+
+import { useTheme } from "@emotion/react";
+import styled from "@emotion/styled";
+
+const Heading1 = styled.h1`
+  ${props => props.theme.heading1};
+  color: ${props => props.color || props.theme.colors.blue['60']};
+`;
+
+export default function Style() {
+  const theme = useTheme();
+  return (
+    <div>
+      <Heading1>Heading1, blue-60 변수 전달 테스트입니다.</Heading1>
+      <Heading1 color={theme.colors.red['50']}>color 프랍에 따라 다른 컬러로도 지정 가능합니다.</Heading1>
+      <Heading1 color={theme.colors.yellow['50']}>코드 재활용을 높혔습니다.</Heading1>
+      <Heading1 color={theme.colors.neutral['50']}>neutral 50</Heading1>
+    </div>);
+}


### PR DESCRIPTION
## 📝 개요

* GlobalStyle을 개발합니다.
* Theme을 이용해 컬러, font stlye 변수를 설정합니다.
* font stlye에서 heading1만 테스트합니다.
* theme 테스트할 라우트인 style라우트를 생성합니다.
* App.tsx에 ThemeProvider, Global을 설정합니다.

![image](https://github.com/oduck-team/oduck-client/assets/139095957/a43b91b3-cfc3-4bc5-8ce3-0d87ef6fe776)


## 🚀 변경사항

없습니다.

## 🔗 관련 이슈
#3 

## ➕ 기타
colors 변수의 prop으로 전달되는 값들의 이름을 피그마에 맞춰 blue, red, neutral 이런식으로 작성해 뒀습니다. 이 네이밍이 아닌 `primary, secondary, warining`으로 적는게 좋을지 리뷰 부탁드립니다.

