### PR TITLE
feat: Portal 컴포넌트

### DIFF
--- a/src/components/Portal/index.tsx
+++ b/src/components/Portal/index.tsx
@@ -1,0 +1,15 @@
+import { createPortal } from "react-dom";
+
+import { StrictPropsWithChildren } from "@/types";
+
+interface PortalProps {
+  elementId: string;
+}
+
+export default function Portal({
+  elementId,
+  children,
+}: StrictPropsWithChildren<PortalProps>) {
+  const portal = document.getElementById(elementId);
+  return portal && createPortal(children, portal);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,10 @@
+import { ReactNode } from "react";
+
+/**
+ * prop에 `children`  반드시 포함하도록 강제하는 역할을 합니다.
+ *
+ * @example StrictPropsWithChildren<ButtonProps>
+ * */
+export type StrictPropsWithChildren<P = unknown> = P & {
+  children: ReactNode;
+};


### PR DESCRIPTION
## 📝 개요

[createPortal](https://react.dev/reference/react-dom/createPortal) API를 이용한 Portal 컴포넌트입니다

## 🚀 변경사항

[feat: prop children 유틸 타입 추가](https://github.com/oduck-team/oduck-client/pull/19/commits/1a0e195f4252e969504bd385c98c2e56e7d0cb5a)

`children`이 있는 컴포넌트에서 `children`이 필요하다고 부모 컴포넌트에게 강제하는 유틸 타입입니다

## 🔗 관련 이슈

#16

## ➕ 기타



