### PR TITLE
feat: 스크롤바 스타일

### DIFF
--- a/src/assets/scrollbar.css
+++ b/src/assets/scrollbar.css
@@ -1,0 +1,21 @@
+* {
+  --sb-track-color: #f4f4f5;
+  --sb-thumb-color: #bcbcbd;
+  --sb-size: 6px;
+
+  scrollbar-color: var(--sb-thumb-color) var(--sb-track-color);
+}
+
+*::-webkit-scrollbar {
+  width: var(--sb-size);
+}
+
+*::-webkit-scrollbar-track {
+  background: var(--sb-track-color);
+  border-radius: 10px;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: var(--sb-thumb-color);
+  border-radius: 10px;
+}

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,2 +1,3 @@
 @import url("./reset.css");
 @import url("./font.css");
+@import url("./scrollbar.css");

--- a/src/features/admin/components/Layout/Menus.tsx
+++ b/src/features/admin/components/Layout/Menus.tsx
@@ -8,13 +8,13 @@ import {
   HeadsetHelp,
 } from "iconoir-react";
 
-type CreateItemProps = {
+interface CreateItemProps {
   key: string;
   label: React.ReactNode;
   icon?: React.ReactNode;
   style?: React.CSSProperties;
   children?: CreateItemProps[];
-};
+}
 
 function createItem(
   key: string,

--- a/src/features/admin/components/Layout/MobileNavigation.style.ts
+++ b/src/features/admin/components/Layout/MobileNavigation.style.ts
@@ -1,0 +1,32 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  position: sticky;
+  top: 0;
+  height: 3.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  background-color: #ffffff;
+  border-bottom: 1px solid #cccccc;
+
+  @media (min-width: 640px) {
+    display: none;
+  }
+`;
+
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const Profile = styled.div`
+  display: flex;
+  align-items: center;
+
+  & p {
+    margin-left: 0.5rem;
+    font-size: 1.125rem;
+    font-weight: bold;
+  }
+`;

--- a/src/features/admin/components/Layout/MobileNavigation.tsx
+++ b/src/features/admin/components/Layout/MobileNavigation.tsx
@@ -1,40 +1,8 @@
-import styled from "@emotion/styled";
 import { Button } from "antd";
 import { Menu, Cancel } from "iconoir-react";
 
 import Menus from "./Menus";
-
-// TODO: 미디어쿼리
-const Container = styled.div({
-  position: "sticky",
-  top: 0,
-  height: "3.5rem",
-
-  paddingLeft: "1rem",
-  paddingRight: "1rem",
-  backgroundColor: "#ffffff",
-  borderBottom: "1px solid #cccccc",
-
-  "@media (min-width: 640px)": {
-    display: "none",
-  },
-});
-
-const Header = styled.div({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "space-between",
-});
-
-const Profile = styled.div({
-  display: "flex",
-  alignItems: "center",
-  "& p": {
-    marginLeft: ".5rem",
-    fontSize: "1.125rem",
-    fontWeight: "bold",
-  },
-});
+import { Container, Header, Profile } from "./MobileNavigation.style";
 
 interface MobileNavigationProps {
   readonly isActive: boolean;

--- a/src/features/admin/components/Layout/Profile.style.ts
+++ b/src/features/admin/components/Layout/Profile.style.ts
@@ -1,0 +1,14 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+
+import { ProfileProps } from "./Profile";
+
+export const Container = styled.div<ProfileProps>`
+  display: flex;
+  flex-direction: column;
+  transition: opacity 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+
+  ${({ isVisible }) => css`
+    opacity: ${isVisible ? 1 : 0};
+  `}
+`;

--- a/src/features/admin/components/Layout/Profile.tsx
+++ b/src/features/admin/components/Layout/Profile.tsx
@@ -1,19 +1,8 @@
-import styled from "@emotion/styled";
 import { Button, Dropdown, MenuProps } from "antd";
 import { LogOut } from "iconoir-react";
 
-const Container = styled.div<ProfileProps>(
-  {
-    display: "flex",
-    flexDirection: "column",
-    transition: "opacity 0.3s cubic-bezier(0.645, 0.045, 0.355, 1)",
-  },
-  ({ isVisible }) => ({
-    opacity: isVisible ? 1 : 0,
-  }),
-);
-
-interface ProfileProps {
+import { Container } from "./Profile.style";
+export interface ProfileProps {
   readonly isVisible: boolean;
 }
 

--- a/src/features/admin/components/Layout/Sidebar.style.ts
+++ b/src/features/admin/components/Layout/Sidebar.style.ts
@@ -1,0 +1,18 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+
+export const Header = styled.div<{ isCollapsed: boolean }>`
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.25rem;
+  overflow: hidden;
+  transition: padding 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+
+  ${({ isCollapsed }) => css`
+    padding-left: ${isCollapsed ? 0 : 0.7}rem;
+  `}
+
+  & h1 {
+    display: none;
+  }
+`;

--- a/src/features/admin/components/Layout/Sidebar.tsx
+++ b/src/features/admin/components/Layout/Sidebar.tsx
@@ -1,30 +1,14 @@
-import styled from "@emotion/styled";
 import { Layout } from "antd";
 import { IconoirProvider } from "iconoir-react";
 
 import Menus from "./Menus";
 import Profile from "./Profile";
+import { Header } from "./Sidebar.style";
 import SidebarToggle from "./SidebarToggle";
 
 const { Sider } = Layout;
 const sidebarWidth = 256; // 사이드바 넓이
 const collapsedWidth = 80; // 사이드바 줄었을때 넓이
-
-const Header = styled.div<{ isCollapsed: boolean }>(
-  {
-    display: "flex",
-    gap: ".5rem",
-    margin: "0.25rem",
-    overflow: "hidden",
-    transition: "padding 0.3s cubic-bezier(0.645, 0.045, 0.355, 1)",
-    "& h1": {
-      display: "none",
-    },
-  },
-  ({ isCollapsed }) => ({
-    paddingLeft: isCollapsed ? "" : ".5rem",
-  }),
-);
 
 interface SidebarProps {
   readonly isCollapsed: boolean;

--- a/src/features/admin/components/Layout/SidebarToggle.style.ts
+++ b/src/features/admin/components/Layout/SidebarToggle.style.ts
@@ -1,0 +1,17 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+
+import { SidebarToggleProps } from "./SidebarToggle";
+
+export const Container = styled.div<SidebarToggleProps>`
+  position: fixed;
+  bottom: 0;
+  height: 80px;
+  display: flex;
+  justify-content: center;
+  transition: all 0.2s;
+
+  ${({ isCollapsed, width, collapsedWidth }) => css`
+    width: ${isCollapsed ? collapsedWidth : width}px;
+  `}
+`;

--- a/src/features/admin/components/Layout/SidebarToggle.tsx
+++ b/src/features/admin/components/Layout/SidebarToggle.tsx
@@ -1,22 +1,9 @@
-import styled from "@emotion/styled";
 import { Button } from "antd";
 import { NavArrowLeft, NavArrowRight } from "iconoir-react";
 
-const Container = styled.div<SidebarToggleProps>(
-  {
-    position: "fixed",
-    bottom: "0",
-    height: "80px",
-    display: "flex",
-    justifyContent: "center",
-    transition: "all 0.2s",
-  },
-  ({ isCollapsed, width, collapsedWidth }) => ({
-    width: isCollapsed ? collapsedWidth : width,
-  }),
-);
+import { Container } from "./SidebarToggle.style";
 
-interface SidebarToggleProps {
+export interface SidebarToggleProps {
   readonly width: number;
   readonly collapsedWidth: number;
   readonly isCollapsed: boolean;


### PR DESCRIPTION
## 📝 개요
스크롤바를 css로 커스텀함
- chrome 기본 스크롤바
<img width="194" alt="스크린샷 2023-08-14 오후 12 43 22" src="https://github.com/oduck-team/oduck-client/assets/105474635/1aee29ce-8280-4a19-a59a-341d0499d321">

- 변경후
<img width="194" alt="스크린샷 2023-08-14 오후 12 43 09" src="https://github.com/oduck-team/oduck-client/assets/105474635/742261f8-0b21-47b3-9ce1-08822682f74d">

## 🚀 변경사항

admin 코드 스타일 변경
- 스타일 코드 `?.style.ts`로 분리
- Object -> 템플릿 리터럴 스타일로 변경

## 🔗 관련 이슈

#35

## ➕ 기타


