### PR TITLE
feat: Drawer 컴포넌트 구현

### DIFF
--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -1,0 +1,36 @@
+import { StrictPropsWithChildren } from "@/types";
+
+import Portal from "../Portal";
+
+import { Backdrop, Container, Content, Header } from "./style";
+
+export type Position = "top" | "right" | "bottom" | "left";
+
+export interface DrawerProps {
+  readonly title?: React.ReactNode;
+  readonly isOpen?: boolean;
+  readonly showBackdrop?: boolean;
+  readonly position: Position;
+  readonly onClose: () => void;
+}
+
+export default function Drawer({
+  title,
+  isOpen = false,
+  showBackdrop = true,
+  position,
+  onClose,
+  children,
+}: StrictPropsWithChildren<DrawerProps>) {
+  if (!isOpen) return null;
+  return (
+    <Portal elementId="modal-root">
+      <Backdrop isVisible={showBackdrop} onClick={onClose}>
+        <Container position={position} onClick={(e) => e.stopPropagation()}>
+          <Header>{title}</Header>
+          <Content>{children}</Content>
+        </Container>
+      </Backdrop>
+    </Portal>
+  );
+}

--- a/src/components/Drawer/style.ts
+++ b/src/components/Drawer/style.ts
@@ -1,0 +1,71 @@
+import { SerializedStyles, css } from "@emotion/react";
+import styled from "@emotion/styled";
+
+import BaseBackdrop from "../Backdrop";
+
+import { DrawerProps, Position } from ".";
+
+const positions: Record<Position, SerializedStyles> = {
+  top: css`
+    width: 100%;
+    height: 470px;
+    top: 0;
+    left: 0;
+    box-shadow:
+      0px 5px 15px 0px rgba(0, 0, 0, 0.1),
+      0px 3px 6px 0px rgba(0, 0, 0, 0.05);
+  `,
+  bottom: css`
+    width: 100%;
+    height: 470px;
+    bottom: 0;
+    left: 0;
+    box-shadow:
+      0px -5px 15px 0px rgba(0, 0, 0, 0.1),
+      0px -3px 6px 0px rgba(0, 0, 0, 0.05);
+  `,
+  left: css`
+    width: 288px;
+    height: 100vh;
+    top: 0;
+    left: 0;
+    box-shadow:
+      -5px 0px 15px 0px rgba(0, 0, 0, 0.1),
+      -3px 0px 6px 0px rgba(0, 0, 0, 0.05);
+  `,
+  right: css`
+    width: 288px;
+    height: 100%;
+    top: 0;
+    right: 0;
+    box-shadow:
+      5px 0px 15px 0px rgba(0, 0, 0, 0.1),
+      3px 0px 6px 0px rgba(0, 0, 0, 0.05);
+  `,
+};
+
+export const Backdrop = styled(BaseBackdrop)`
+  z-index: ${({ theme }) => theme.zIndex.drawer};
+`;
+
+export const Container = styled.div<Pick<DrawerProps, "position">>`
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+
+  ${({ position }) => positions[position]}
+`;
+
+export const Header = styled.div`
+  display: flex;
+  padding: 0.875rem;
+
+  ${({ theme }) => theme.typo["title-3-b"]}
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 0.875rem;
+`;

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -7,31 +7,32 @@ const REGULAR = 400;
 const LETTER_SPACING = "-0.02em"; // -2%
 
 /** @description css 스타일에서 사용할 것 */
-// const generateTypography = (
-//   size: number,
-//   weight: number,
-//   letterSpacing?: string,
-// ) => css`
-//   font-family: "Spoqa Han Sans Neo", "sans-serif", "system-ui";
-//   font-style: normal;
-//   line-height: 150%;
-//   font-weight: ${weight};
-//   font-size: ${size}px;
-//   ${letterSpacing && `letter-spacing: ${letterSpacing};`}
-// `;
-
 const generateTypography = (
   size: number,
   weight: number,
   letterSpacing?: string,
-) => ({
-  fontFamily: '"Spoqa Han Sans Neo", "sans-serif", "system-ui"',
-  fontStyle: "normal",
-  lineHeight: "150%",
-  fontWeight: weight,
-  fontSize: `${size}px`,
-  ...(letterSpacing && { letterSpacing: letterSpacing }),
-});
+) => css`
+  font-family: "Spoqa Han Sans Neo", "sans-serif", "system-ui";
+  font-style: normal;
+  line-height: 150%;
+  font-weight: ${weight};
+  font-size: ${size}px;
+  ${letterSpacing && `letter-spacing: ${letterSpacing};`}
+`;
+
+/** @description Object 스타일에서 사용할 것 */
+// const generateTypography = (
+//   size: number,
+//   weight: number,
+//   letterSpacing?: string,
+// ) => ({
+//   fontFamily: '"Spoqa Han Sans Neo", "sans-serif", "system-ui"',
+//   fontStyle: "normal",
+//   lineHeight: "150%",
+//   fontWeight: weight,
+//   fontSize: `${size}px`,
+//   ...(letterSpacing && { letterSpacing: letterSpacing }),
+// });
 
 export type Typography = typeof typo;
 


### PR DESCRIPTION
## 📝 개요

Drawer 컴포넌트를 구현 함
```ts
export type Position = "top" | "right" | "bottom" | "left";

export interface DrawerProps {
  readonly title?: React.ReactNode;
  readonly isOpen?: boolean;
  readonly showBackdrop?: boolean;
  readonly position: Position;
  readonly onClose: () => void;
}

export default function Drawer({
  title,
  isOpen = false,
  showBackdrop = true,
  position,
  onClose,
  children,
}: StrictPropsWithChildren<DrawerProps>) {
  if (!isOpen) return null;
  return (
    <Portal elementId="modal-root">
      <Backdrop isVisible={showBackdrop} onClick={onClose}>
        <Container position={position} onClick={(e) => e.stopPropagation()}>
          <Header>{title}</Header>
          <Content>{children}</Content>
        </Container>
      </Backdrop>
    </Portal>
  );
}
```

https://github.com/oduck-team/oduck-client/assets/105474635/7cbaea54-afc8-4654-849f-3172081459ef

<img width="501" alt="스크린샷 2023-08-16 오전 11 45 23" src="https://github.com/oduck-team/oduck-client/assets/105474635/bd571d6a-83fa-4f6e-ac79-4f2e5a67566e">
<img width="501" alt="스크린샷 2023-08-16 오전 11 45 32" src="https://github.com/oduck-team/oduck-client/assets/105474635/2f78c87b-e77c-419d-a893-dd4d96d2ffe3">
<img width="501" alt="스크린샷 2023-08-16 오전 11 45 48" src="https://github.com/oduck-team/oduck-client/assets/105474635/2f6901d5-0b73-4836-9f17-01159cde406b">



## 🚀 변경사항
[style: typo 템플릿 리터럴 함수로 변경](https://github.com/oduck-team/oduck-client/commit/e53b72ee6fea5bb5918b901cab9def14a78dab0f)
emotion 스타일을 객체 리터럴에서 템플릿 리터럴로 변경함에 따라 반영

## 🔗 관련 이슈

#37

## ➕ 기타
- 애니메이션 라이브러리를 써서 모달, 바텀시트, 드로어 등 등장시 사용해도 좋을 것 같아요

