### PR TITLE
feat: 로그인 임시 화면

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import AdminLayout from "./features/admin/components/Layout";
 import Dashboard from "./features/admin/routes/Dashboard";
 import AnimationDetail from "./features/animations/routes/Detail";
 import AnimationList from "./features/animations/routes/List";
+import Login from "./features/auth/routes/Login";
 import NotFound from "./features/common/routes/404";
 import HelpDesk from "./features/common/routes/HelpDesk";
 import Home from "./features/common/routes/Home";
@@ -25,6 +26,7 @@ export default function App() {
           }}
         >
           <Routes>
+            <Route path="/login" element={<Login />} />
             <Route path="/" element={<Layout />}>
               <Route path="" element={<Home />} />
               <Route path="/animations" element={<AnimationList />} />

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -31,6 +31,7 @@ export default function Button({
   if (isIconOnly) {
     return (
       <IconButton
+        aria-label={name}
         styleType={styleType}
         color={color}
         size={size}

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -14,6 +14,7 @@ export interface ButtonProps extends ComponentProps<"button"> {
   readonly styleType?: Style;
   readonly color?: Color;
   readonly size?: Size;
+  readonly isBlock?: boolean;
   readonly icon?: React.ReactNode;
 }
 
@@ -23,10 +24,12 @@ export default function Button({
   color = "primary",
   size = "md",
   type = "button",
+  isBlock = false,
   icon,
   children,
   ...props
 }: ButtonProps) {
+  console.log(isBlock);
   const isIconOnly = icon !== undefined && !children;
   if (isIconOnly) {
     return (
@@ -50,6 +53,7 @@ export default function Button({
       color={color}
       size={size}
       type={type}
+      isBlock={isBlock}
       {...props}
     >
       <ContentWrapper>

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -10,6 +10,7 @@ type ColorKeys = "primary" | "neutral" | "warn";
 export type Size = "lg" | "md" | "sm";
 
 export interface ButtonProps extends ComponentProps<"button"> {
+  readonly name: string;
   readonly styleType?: Style;
   readonly color?: Color;
   readonly size?: Size;
@@ -17,6 +18,7 @@ export interface ButtonProps extends ComponentProps<"button"> {
 }
 
 export default function Button({
+  name,
   styleType = "solid",
   color = "primary",
   size = "md",
@@ -42,6 +44,7 @@ export default function Button({
 
   return (
     <Container
+      aria-label={name}
       styleType={styleType}
       color={color}
       size={size}

--- a/src/components/Button/style.ts
+++ b/src/components/Button/style.ts
@@ -108,9 +108,10 @@ const baseStyle = css`
 `;
 
 export const Container = styled.button<
-  Pick<ButtonProps, "styleType" | "color" | "size">
+  Pick<ButtonProps, "styleType" | "color" | "size" | "isBlock">
 >`
   ${baseStyle}
+  width: ${({ isBlock }) => (isBlock ? "100%" : "auto")};
 
   ${({ styleType = "solid", color = "primary", size = "md", theme }) => css`
     ${buttonSizes[size]}

--- a/src/components/ResponsiveContainer/index.tsx
+++ b/src/components/ResponsiveContainer/index.tsx
@@ -1,0 +1,19 @@
+import { StrictPropsWithChildren } from "@/types";
+
+import { Container } from "./style";
+
+interface ContainerProps {
+  readonly htmlType?: React.ElementType;
+}
+
+export default function ResponsiveContainer({
+  htmlType = "div",
+  children,
+  ...props
+}: StrictPropsWithChildren<ContainerProps>) {
+  return (
+    <Container as={htmlType} {...props}>
+      {children}
+    </Container>
+  );
+}

--- a/src/components/ResponsiveContainer/style.ts
+++ b/src/components/ResponsiveContainer/style.ts
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  ${({ theme }) => theme.container}
+`;

--- a/src/features/auth/routes/Login.tsx
+++ b/src/features/auth/routes/Login.tsx
@@ -40,13 +40,19 @@ export default function Login() {
           </Title>
           <SoicalGroup>
             <li>
-              <Button name="1">TODO로 로그인</Button>
+              <Button name="1" isBlock>
+                TODO로 로그인
+              </Button>
             </li>
             <li>
-              <Button name="1">TODO로 로그인</Button>
+              <Button name="1" isBlock>
+                TODO로 로그인
+              </Button>
             </li>
             <li>
-              <Button name="1">TODO로 로그인</Button>
+              <Button name="1" isBlock>
+                TODO로 로그인
+              </Button>
             </li>
           </SoicalGroup>
         </MainContent>

--- a/src/features/auth/routes/Login.tsx
+++ b/src/features/auth/routes/Login.tsx
@@ -1,0 +1,102 @@
+import styled from "@emotion/styled";
+import { ArrowLeft } from "iconoir-react";
+import { useNavigate } from "react-router-dom";
+
+import Button from "@/components/Button";
+import Head from "@/components/Head";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
+
+export default function Login() {
+  const navigate = useNavigate();
+
+  const handleClickBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <>
+      <Head
+        title="오덕 | 로그인"
+        description="오덕에 회원가입 없이 빠르게 덕질을 시작해 보세요!"
+      />
+      <header>
+        <HeaderContent>
+          <Button
+            name="뒤로가기"
+            icon={<ArrowLeft />}
+            styleType="text"
+            color="neutral"
+            onClick={handleClickBack}
+          />
+          {/* TODO: Logo component  */}
+          <a>로고</a>
+        </HeaderContent>
+      </header>
+      <main>
+        <MainContent htmlType={"div"}>
+          <h1>오덕에 로그인</h1>
+          <Title>
+            회원가입 없이 <br /> 빠르게 <span>덕질</span>을 시작해 보세요!
+          </Title>
+          <SoicalGroup>
+            <li>
+              <Button name="1">TODO로 로그인</Button>
+            </li>
+            <li>
+              <Button name="1">TODO로 로그인</Button>
+            </li>
+            <li>
+              <Button name="1">TODO로 로그인</Button>
+            </li>
+          </SoicalGroup>
+        </MainContent>
+      </main>
+    </>
+  );
+}
+
+const HeaderContent = styled.div`
+  ${({ theme }) => theme.container}
+  display: flex;
+  align-items: center;
+  height: 56px;
+  padding: 0 1rem;
+  margin: 0 auto;
+
+  /* TODO: Logo component */
+  & > a {
+    margin: 0 auto;
+  }
+
+  & > button {
+    position: absolute;
+    margin-left: 0;
+  }
+`;
+
+const MainContent = styled(ResponsiveContainer)`
+  padding: 0 1rem;
+  margin: 0 auto;
+
+  & > h1 {
+    display: none;
+  }
+`;
+
+const Title = styled.p`
+  ${({ theme }) => theme.typo["heading-1"]}
+  ${({ theme }) => theme.container}
+  margin-top: 48px;
+  margin-bottom: 24px;
+
+  & > span {
+    color: ${({ theme }) => theme.colors.primary["60"]};
+  }
+`;
+
+const SoicalGroup = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 24px;
+`;

--- a/src/styles/container.ts
+++ b/src/styles/container.ts
@@ -1,0 +1,16 @@
+import { css } from "@emotion/react";
+
+import { breakPoints } from "./mediaQuery";
+
+const maxWidths = Object.entries(breakPoints)
+  .map(
+    ([_, value]) => `@media (min-width: ${value}px) {
+    max-width: ${value}px;
+  }`,
+  )
+  .join("");
+
+export const container = css`
+  width: 100%;
+  ${maxWidths};
+`;

--- a/src/styles/emotion.d.ts
+++ b/src/styles/emotion.d.ts
@@ -1,6 +1,7 @@
 import "@emotion/react";
 
 import { Colors } from "./colors";
+import { Container } from "./container";
 import { MediaQuery } from "./mediaQuery";
 import { Typography } from "./typography";
 import { ZIndex } from "./z-index";
@@ -17,5 +18,6 @@ declare module "@emotion/react" {
     typo: Typography;
     zIndex: ZIndex;
     mq: MediaQuery;
+    container: Container;
   }
 }

--- a/src/styles/emotion.d.ts
+++ b/src/styles/emotion.d.ts
@@ -3,7 +3,7 @@ import "@emotion/react";
 import { Colors } from "./colors";
 import { MediaQuery } from "./mediaQuery";
 import { Typography } from "./typography";
-import { zIndex } from "./z-index";
+import { ZIndex } from "./z-index";
 
 // Theme 타입에 colors, typo 프로퍼티를 추가하여 확장합니다.
 declare module "@emotion/react" {
@@ -15,7 +15,7 @@ declare module "@emotion/react" {
       neutral: Colors["neutral"];
     };
     typo: Typography;
-    zIndex: typeof zIndex;
+    zIndex: ZIndex;
     mq: MediaQuery;
   }
 }

--- a/src/styles/mediaQuery.ts
+++ b/src/styles/mediaQuery.ts
@@ -1,12 +1,12 @@
-const breakPoints = {
+export type MediaQuery = typeof mq;
+
+export const breakPoints = {
   xs: 420,
   sm: 576,
   md: 768,
   lg: 900,
   xl: 1200,
-};
+} as const;
 
 export const mq = (bp: keyof typeof breakPoints) =>
   `@media (min-width: ${breakPoints[bp]}px)`;
-
-export type MediaQuery = typeof mq;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,7 @@
 import { Theme } from "@emotion/react";
 
 import { colors } from "./colors";
+import { container } from "./container";
 import { mq } from "./mediaQuery";
 import { typo } from "./typography";
 import { zIndex } from "./z-index";
@@ -15,4 +16,5 @@ export const theme: Theme = {
   typo,
   zIndex,
   mq,
+  container,
 };

--- a/src/styles/z-index.ts
+++ b/src/styles/z-index.ts
@@ -7,3 +7,5 @@ export const zIndex = {
   toast: 1400,
   tooltip: 1500,
 } as const;
+
+export type ZIndex = typeof zIndex;


### PR DESCRIPTION
## 📝 개요

- 로고, 소셜 로그인 버튼이 없는 로그인 임시 화면을 구현 [feat: 임시 로그인 화면](https://github.com/oduck-team/oduck-client/pull/48/commits/453c1b79e1456e07652c2aaab498c4d6e2e54198) ⭐️

https://github.com/oduck-team/oduck-client/assets/105474635/fd79dde0-0de3-440a-bb34-4cf1a7751c11


- [style: 컨테이너 스타일 및 theme에 컨테이너 추가](https://github.com/oduck-team/oduck-client/commit/ca26213b86118e5aed64cedbd473653b19fde3d8) ⭐️
  다음 코드로 간단하게 페이지 컨테이너를 사용할 수 있음
```ts
 ${({ theme }) => theme.container} 
```
- 위를 사용한 반응형 컨테이너 컴포넌트 구현
[feat: 반응형 컨테이너 컴포넌트](https://github.com/oduck-team/oduck-client/commit/6d692ce3f5447d5edb639ce7782552fed8039575) ⭐️
## 🚀 변경사항

[refactor: 웹 접근성을 위한 Button aria-label 추가](https://github.com/oduck-team/oduck-client/commit/0b446b820f30e6587c118b4c9d64e283273a41a4) ⭐️
[refactor: 웹 접근성을 위한 IconButton aria-label 추가](https://github.com/oduck-team/oduck-client/commit/4d3525f6c59220138e3994aa64ad56f3fe6c3c96) ⭐️
[refactor: zIndex 코드 스타일 통합 (typeof -> type)](https://github.com/oduck-team/oduck-client/commit/ab5cf252e96669b8ca6c3b70d5bd0262cbe6eb90)
[refactor: breakPoints as const 처리](https://github.com/oduck-team/oduck-client/pull/48/commits/4edddaf69d6ee1cb28269446e7f438f03499a0d2)
## 🔗 관련 이슈

#47 

## ➕ 기타


- 버튼에 width를 100%로주는 prop 추가가 필요합니다!
