### PR TITLE
feat: 랜딩페이지 상단 캐러셀

### DIFF
--- a/src/features/home/components/Carousel.style.ts
+++ b/src/features/home/components/Carousel.style.ts
@@ -1,0 +1,204 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+
+interface SlideProps {
+  image: string;
+}
+
+interface SlidesProps {
+  translateValue: number;
+  transitionValue: number;
+}
+
+interface IndicatorProps {
+  active: boolean;
+}
+
+const ellipsis = css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-all;
+`;
+
+export const Container = styled.div`
+  width: 100%;
+  height: 558px;
+  overflow: hidden;
+  position: relative;
+`;
+
+export const Background = styled.div<SlideProps>`
+  width: 100%;
+  height: 100%;
+  background: ${({
+    image,
+  }) => `linear-gradient(0deg, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.5) 100%),
+    url(${image}),
+    lightgray -36.515px 1.434px / 119.018% 99.743% no-repeat`};
+
+  background-size: cover;
+  filter: blur(5px);
+  transform: scale(1.05);
+`;
+
+export const SlideContainer = styled.div`
+  --width: calc(100% - 32px);
+  width: var(--width);
+  height: 442.699px;
+  overflow: hidden;
+  position: absolute;
+  top: 55px;
+  left: calc(50% - (var(--width) / 2));
+  z-index: 500; // 논의 필요
+  border-radius: 17px;
+
+  & > button {
+    ${({ theme }) => theme.mq("md")} {
+      display: block;
+    }
+    display: none;
+    position: absolute;
+    z-index: 600;
+    color: rgba(255, 255, 255, 0.6);
+    top: calc(50% - 15px);
+
+    &:hover {
+      color: rgba(255, 255, 255, 0.9);
+    }
+
+    &:not([disabled]):active {
+      color: rgba(255, 255, 255, 0.9);
+      background: none;
+      border-color: rgba(0, 0, 0, 0);
+    }
+
+    :last-of-type {
+      right: 3px;
+    }
+  }
+`;
+
+export const Slides = styled.div<SlidesProps>`
+  width: calc(100% * 6);
+  height: 100%;
+  display: flex;
+  touch-action: pan-x;
+  transform: ${({ translateValue }) => `translateX(${translateValue}px)`};
+  transition: ${({ transitionValue }) => `all ${transitionValue}s`};
+`;
+
+export const Slide = styled.div<SlideProps>`
+  width: calc(100% / 6);
+  height: 100%;
+  border-radius: 17px;
+  ${({ image }) => css`
+    background:
+      linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.8) 100%),
+      url(${image}),
+      lightgray -31.19px 1.138px / 119.018% 99.743% no-repeat;
+  `}
+  background-size: cover;
+  box-shadow: 0px 0px 19px 0px rgba(0, 0, 0, 0.17);
+  padding: 0 16px 42px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  color: white;
+`;
+
+export const InfoContainer = styled.div`
+  width: 100%;
+  height: fit-content;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+`;
+
+export const Info = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  color: white;
+
+  & > div:first-of-type {
+    width: 100%;
+    ${ellipsis}
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    ${({ theme }) => theme.mq("md")} {
+      ${({ theme }) => theme.typo["heading-1"]}
+    }
+    ${({ theme }) => theme.typo["title-2-m"]}
+  }
+`;
+
+export const Review = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 54px;
+
+  & > span:first-of-type {
+    ${({ theme }) => theme.mq("md")} {
+      ${({ theme }) => theme.typo["title-2-m"]}
+    }
+    ${({ theme }) => theme.typo["body-3-r"]}
+
+    opacity: 0.9;
+    width: 66.7%; // 논의 필요
+    /* width: 207px; */
+    ${ellipsis}
+    white-space: nowrap;
+  }
+`;
+
+export const Rating = styled.div`
+  color: ${({ theme }) => theme.colors["secondary"]["50"]};
+  ${({ theme }) => theme.mq("md")} {
+    font-size: 20px;
+  }
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1rem;
+  letter-spacing: -0.7px;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+
+  & > svg {
+    ${({ theme }) => theme.mq("md")} {
+      width: 20px;
+      height: 20px;
+    }
+    width: 14px;
+    height: 14px;
+    margin-bottom: 1px; // 아이콘 위치 숫자와 맞게 조정
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    fill: ${({ theme }) => theme.colors["secondary"]["50"]};
+  }
+`;
+
+export const IndicatorContainer = styled.div`
+  display: flex;
+  gap: 6px;
+  position: absolute;
+  left: calc(50% - 21px);
+  bottom: 20.7px;
+  z-index: 600;
+`;
+
+export const Indicator = styled.span<IndicatorProps>`
+  background-color: ${({ active, theme }) =>
+    active ? "white" : theme.colors["neutral"]["50"]};
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+`;

--- a/src/features/home/components/Carousel.style.ts
+++ b/src/features/home/components/Carousel.style.ts
@@ -85,6 +85,7 @@ export const Slides = styled.div<SlidesProps>`
   touch-action: pan-x;
   transform: ${({ translateValue }) => `translateX(${translateValue}px)`};
   transition: ${({ transitionValue }) => `all ${transitionValue}s`};
+  cursor: pointer;
 `;
 
 export const Slide = styled.div<SlideProps>`

--- a/src/features/home/components/Carousel.style.ts
+++ b/src/features/home/components/Carousel.style.ts
@@ -49,7 +49,7 @@ export const SlideContainer = styled.div`
   position: absolute;
   top: 55px;
   left: calc(50% - (var(--width) / 2));
-  z-index: 500; // 논의 필요
+  z-index: ${({ theme }) => theme.zIndex.carousel};
   border-radius: 17px;
 
   & > button {
@@ -58,7 +58,7 @@ export const SlideContainer = styled.div`
     }
     display: none;
     position: absolute;
-    z-index: 600;
+    z-index: ${({ theme }) => theme.zIndex.carousel + 1};
     color: rgba(255, 255, 255, 0.6);
     top: calc(50% - 15px);
 
@@ -193,7 +193,7 @@ export const IndicatorContainer = styled.div`
   position: absolute;
   left: calc(50% - 21px);
   bottom: 20.7px;
-  z-index: 600;
+  z-index: ${({ theme }) => theme.zIndex.carousel + 1};
 `;
 
 export const Indicator = styled.span<IndicatorProps>`

--- a/src/features/home/components/Carousel.tsx
+++ b/src/features/home/components/Carousel.tsx
@@ -1,0 +1,207 @@
+import { NavArrowLeft, NavArrowRight, Star } from "iconoir-react";
+import { useEffect, useRef, useState } from "react";
+
+import Button from "@/components/Button";
+
+import {
+  Container,
+  Background,
+  SlideContainer,
+  Slides,
+  Slide,
+  InfoContainer,
+  Info,
+  Indicator,
+  IndicatorContainer,
+  Rating,
+  Review,
+} from "./Carousel.style";
+
+export interface Animation {
+  id: string;
+  title: string;
+  image: string;
+  review: string;
+  rating: number;
+}
+
+interface Props {
+  animations: Animation[];
+}
+
+export default function Carousel({ animations }: Props) {
+  const [current, setCurrent] = useState(1);
+  const [translateValue, setTranslateValue] = useState(0);
+  const [transitionValue, setTransitionValue] = useState(0);
+  const touchStartX = useRef<number | null>(null);
+  const slideContainerRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState<number | null>(null); // 슬라이드 박스 가로 길이
+
+  // 무한 캐러셀을 위한 배열 확장
+  const animationsList = [
+    animations[animations.length - 1],
+    ...animations,
+    animations[0],
+  ];
+
+  // 모바일 이벤트
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+    setTransitionValue(0);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    setTransitionValue(0);
+    const touchCurrentX = e.touches[0].clientX;
+    const diff = touchCurrentX - touchStartX.current;
+    setTranslateValue(translateValue + diff);
+    touchStartX.current = touchCurrentX;
+  };
+
+  const handleTouchEnd = () => {
+    if (width) {
+      setTransitionValue(0.5);
+      const newIndex = Math.min(
+        Math.max(Math.round(-translateValue / width), 0),
+        animationsList.length - 1,
+      );
+      setCurrent(newIndex);
+      setTranslateValue(width * -newIndex);
+    }
+    touchStartX.current = null;
+  };
+
+  // 처음, 마지막 슬라이드일 때 수행
+  const goTo = (width: number, i: number) => {
+    setCurrent(i);
+    setTimeout(() => {
+      setTranslateValue(width * -i);
+      setTransitionValue(0);
+    }, 500);
+  };
+
+  // 다음 슬라이드 이동
+  const goNext = () => {
+    if (current < animationsList.length - 1 && width) {
+      setTransitionValue(0.5);
+      setTranslateValue(width * -(current + 1));
+      setCurrent((prev) => prev + 1);
+    }
+  };
+
+  // 이전 슬라이드 이동
+  const goPrev = () => {
+    if (current > 0 && width) {
+      setTransitionValue(0.5);
+      setTranslateValue(width * -(current - 1));
+      setCurrent((prev) => prev - 1);
+    }
+  };
+
+  // 슬라이드 초기 위치(=1) 및 가로 길이 설정
+  useEffect(() => {
+    if (slideContainerRef.current) {
+      const w = slideContainerRef.current.getBoundingClientRect().width;
+      setWidth(w);
+      setTranslateValue(-w);
+    }
+  }, []);
+
+  // 5초마다 자동 슬라이드
+  useEffect(() => {
+    const timer = setInterval(() => {
+      goNext();
+    }, 5000);
+    return () => {
+      clearInterval(timer);
+    };
+  });
+
+  // 창 크기가 변할 때마다 자연스럽게 가로 길이 재설정
+  useEffect(() => {
+    const handleResize = () => {
+      if (slideContainerRef.current) {
+        const w = slideContainerRef.current.getBoundingClientRect().width;
+        setWidth(w);
+        setTranslateValue(w * -current);
+        setTransitionValue(0);
+      }
+    };
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [current]);
+
+  // 처음, 마지막 슬라이드일 때 이동
+  useEffect(() => {
+    if (width) {
+      if (current === 5) {
+        goTo(width, 1);
+      }
+      if (current === 0) {
+        goTo(width, 4);
+      }
+    }
+  }, [current, width]);
+
+  return (
+    <Container>
+      <SlideContainer ref={slideContainerRef}>
+        <Button
+          name="이전"
+          styleType="text"
+          color="neutral"
+          size="lg"
+          icon={<NavArrowLeft />}
+          onClick={goPrev}
+        ></Button>
+        <Button
+          name="다음"
+          styleType="text"
+          color="neutral"
+          size="lg"
+          icon={<NavArrowRight />}
+          onClick={goNext}
+        ></Button>
+        <Slides
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          translateValue={translateValue}
+          transitionValue={transitionValue}
+        >
+          {animationsList.map((ani, i) => (
+            <SlideItem ani={ani} key={i} />
+          ))}
+        </Slides>
+        <IndicatorContainer>
+          {[...Array(animations.length)].map((a, i) => (
+            <Indicator active={current - 1 === i} key={i}></Indicator>
+          ))}
+        </IndicatorContainer>
+      </SlideContainer>
+      <Background image={animationsList[current].image}></Background>
+    </Container>
+  );
+}
+
+const SlideItem = ({ ani }: { ani: Animation }) => {
+  return (
+    <Slide image={ani.image}>
+      <InfoContainer>
+        <Info>
+          <div>{ani.title}</div>
+          <Review>
+            <span>{ani.review}</span>
+            <Rating>
+              <Star />
+              <span> {ani.rating}</span>
+            </Rating>
+          </Review>
+        </Info>
+      </InfoContainer>
+    </Slide>
+  );
+};

--- a/src/features/home/components/Carousel.tsx
+++ b/src/features/home/components/Carousel.tsx
@@ -1,5 +1,6 @@
 import { NavArrowLeft, NavArrowRight, Star } from "iconoir-react";
 import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import Button from "@/components/Button";
 
@@ -188,8 +189,9 @@ export default function Carousel({ animations }: Props) {
 }
 
 const SlideItem = ({ ani }: { ani: Animation }) => {
+  const navigate = useNavigate();
   return (
-    <Slide image={ani.image}>
+    <Slide image={ani.image} onClick={() => navigate(`/animations/${ani.id}`)}>
       <InfoContainer>
         <Info>
           <div>{ani.title}</div>

--- a/src/styles/z-index.ts
+++ b/src/styles/z-index.ts
@@ -6,6 +6,7 @@ export const zIndex = {
   snackbar: 1400,
   toast: 1400,
   tooltip: 1500,
+  carousel: 500,
 } as const;
 
 export type ZIndex = typeof zIndex;


### PR DESCRIPTION
## 📝 개요
랜딩페이지 내 상단 캐러셀을 구현
5초마다 자동 슬라이드 됩니다. (영상은 사용자가 직접 슬라이드 하는 부분만 넣었습니다.)
<br/>

### 모바일 버전

https://github.com/oduck-team/oduck-client/assets/80813703/1f1e60cd-8eff-4ecb-a433-32a1f3a3752e


### PC 버전

https://github.com/oduck-team/oduck-client/assets/80813703/cbd9350a-2fdb-4b91-a479-2ca92bcb25f1

<br/>

## 🔗 관련 이슈
#41

<br/>

## ➕ 기타
1. 해당 캐러셀이 랜딩페이지에서만 사용되는 것 같아 feature/home/components 폴더 내에 두었습니다.
Home 컴포넌트 위치를 home/routes 폴더 내로 옮길지 그대로 둘지 의견 주시면 반영하겠습니다.

2. 리뷰 텍스트 영역 가로 길이에 대한 논의가 필요합니다.  모바일은 피그마와 유사하게 했는데, PC는 길이가 괜찮게 보이는지 모르겠네요.

3. 구현 중에 z-index를 임의로 사용했는데 이 값도 수정이 필요하다면 말씀해 주세요. 

4. 애니메이션 interface는 테스트를 위해 임의로 정의했습니다. 위치나 타입 등등 의견 말씀해주세요 🙇🏻‍♀

5. 그 외 스타일 및 전반적인 코드 피드백 부탁드립니다!!
