### PR TITLE
feat: 사용자 레이아웃 sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,13 +28,14 @@ export default function App() {
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route path="/" element={<Layout />}>
-              <Route path="" element={<Home />} />
+              <Route index path="" element={<Home />} />
               <Route path="/animations" element={<AnimationList />} />
               <Route path="/animations/:id" element={<AnimationDetail />} />
               <Route path="/search" element={<Search />} />
               <Route path="/helpdesk" element={<HelpDesk />} />
               {/* TODO: 인증 */}
               <Route path="/users/:id" element={<UserProfile />} />
+              <Route path="/profile" element={<UserProfile />} />
             </Route>
             <Route path="/admin" element={<AdminLayout />}>
               <Route path="" element={<Dashboard />} />

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -3,17 +3,17 @@ import { Container, UserImage, UserName } from "./style";
 export type Size = "xl" | "lg" | "md" | "sm";
 
 export interface AvatarProps {
-  readonly username: string;
+  readonly userName: string;
   readonly src?: string;
   readonly size?: Size;
 }
 
-export default function Avatar({ username, src, size = "md" }: AvatarProps) {
-  const displayName = username.slice(0, 2); // 사용자이름 첫 두글자만 화면에 표시
+export default function Avatar({ userName, src, size = "md" }: AvatarProps) {
+  const displayName = userName.slice(0, 2); // 사용자이름 첫 두글자만 화면에 표시
 
   return (
     <Container size={size}>
-      {src && <UserImage src={src} alt={username} />}
+      {src && <UserImage src={src} alt={userName} />}
       {!src && <UserName size={size}>{displayName}</UserName>}
     </Container>
   );

--- a/src/components/BottomNavigation/index.tsx
+++ b/src/components/BottomNavigation/index.tsx
@@ -2,8 +2,8 @@ import { useNavigate } from "react-router-dom";
 
 import { Container, Item } from "./style";
 
-interface NavigationItem {
-  readonly key: string;
+export interface INavigationItem {
+  readonly id: string;
   readonly to: string;
   readonly icon: React.ReactNode;
   readonly label: React.ReactNode;
@@ -11,23 +11,23 @@ interface NavigationItem {
 
 interface BottomNavigationProps {
   readonly title: string;
-  readonly activeKey?: string; // 활성화(선택된) item의 key
-  readonly items: NavigationItem[];
-  readonly onClickItem?: (key: string, e: React.MouseEvent) => void;
+  readonly activeId?: string; // 활성화(선택된) item의 id
+  readonly items: INavigationItem[];
+  readonly onClickItem?: (id: string, e: React.MouseEvent) => void;
 }
 
 export default function BottomNavigation({
   title = "네비게이션",
-  activeKey,
+  activeId,
   items,
   onClickItem,
 }: BottomNavigationProps) {
   const navigate = useNavigate();
 
-  const handleItemClick = (key: string, to: string, e: React.MouseEvent) => {
+  const handleItemClick = (id: string, to: string, e: React.MouseEvent) => {
     e.preventDefault();
     if (onClickItem) {
-      onClickItem(key, e);
+      onClickItem(id, e);
     } else {
       navigate(to); // onClickItem이 없을땐 라우팅 처리
     }
@@ -38,11 +38,11 @@ export default function BottomNavigation({
       <h1>{title}</h1>
       <ul>
         {items.map((item) => (
-          <li key={item.key}>
+          <li key={item.id}>
             <Item
-              isActive={activeKey === item.key}
+              isActive={activeId === item.id}
               href={item.to}
-              onClick={(e) => handleItemClick(item.key, item.to, e)}
+              onClick={(e) => handleItemClick(item.id, item.to, e)}
             >
               {item.icon}
               <span>{item.label}</span>

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -29,7 +29,6 @@ export default function Button({
   children,
   ...props
 }: ButtonProps) {
-  console.log(isBlock);
   const isIconOnly = icon !== undefined && !children;
   if (isIconOnly) {
     return (

--- a/src/components/Layout/Menu.style.ts
+++ b/src/components/Layout/Menu.style.ts
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.li`
+  border-radius: 6px;
+  transition: colors 0.2s;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.neutral["05"]};
+  }
+  &:active {
+    background-color: ${({ theme }) => theme.colors.neutral["10"]};
+  }
+
+  & > a {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0 1rem;
+    height: 40px;
+  }
+`;

--- a/src/components/Layout/Menu.tsx
+++ b/src/components/Layout/Menu.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+
+import { Container } from "./Menu.style";
+
+export interface IMenu {
+  readonly id: string;
+  readonly title: string;
+  readonly to: string;
+  readonly icon: React.ReactNode;
+}
+
+interface MenuProps {
+  readonly menu: IMenu;
+  readonly onClick: (id: string, e: React.MouseEvent) => void;
+}
+
+export default function Menu({ menu, onClick }: MenuProps) {
+  return (
+    <Container onClick={(e) => onClick(menu.id, e)}>
+      <Link to={menu.to}>
+        {menu.icon}
+        {menu.title}
+      </Link>
+    </Container>
+  );
+}

--- a/src/components/Layout/Menus.style.ts
+++ b/src/components/Layout/Menus.style.ts
@@ -1,0 +1,33 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 40px 0;
+
+  & > a {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+`;
+
+export const UserMenus = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+`;
+
+export const HelpMenus = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+`;
+
+export const Divider = styled.div`
+  margin: 1rem 0;
+  height: 1px;
+  background-color: ${({ theme }) => theme.colors.neutral["30"]};
+`;

--- a/src/components/Layout/Menus.tsx
+++ b/src/components/Layout/Menus.tsx
@@ -1,0 +1,70 @@
+import { HeadsetHelp, Megaphone, PeopleTag, Settings, Tv } from "iconoir-react";
+
+import Menu, { IMenu } from "./Menu";
+import { Container, Divider, HelpMenus, UserMenus } from "./Menus.style";
+
+const userMenuItems: IMenu[] = [
+  {
+    id: "profile",
+    title: "프로필",
+    to: "/profile",
+    icon: <PeopleTag />,
+  },
+  {
+    id: "bookmark",
+    title: "입덕 애니",
+    to: "/my-animations",
+    icon: <Tv />,
+  },
+  {
+    id: "settings",
+    title: "설정",
+    to: "/settings",
+    icon: <Settings />,
+  },
+];
+
+const helpMenuItems: IMenu[] = [
+  {
+    id: "notice",
+    title: "공지사항",
+    to: "/notices",
+    icon: <Megaphone />,
+  },
+  {
+    id: "helpdesk",
+    title: "고객센터",
+    to: "/helpdesk",
+    icon: <HeadsetHelp />,
+  },
+];
+
+export default function Menus() {
+  const handleClickUserMenu = (id: string, e: React.MouseEvent) => {
+    e.preventDefault();
+    // TODO: id와 인증상태에 따른 처리
+    return;
+  };
+
+  const handleClickHelpMenu = (id: string, e: React.MouseEvent) => {
+    e.preventDefault();
+    // TODO: id와 인증상태에 따른 처리
+    return;
+  };
+
+  return (
+    <Container>
+      <UserMenus>
+        {userMenuItems.map((item) => (
+          <Menu key={item.id} menu={item} onClick={handleClickUserMenu} />
+        ))}
+      </UserMenus>
+      <Divider />
+      <HelpMenus>
+        {helpMenuItems.map((item) => (
+          <Menu key={item.id} menu={item} onClick={handleClickHelpMenu} />
+        ))}
+      </HelpMenus>
+    </Container>
+  );
+}

--- a/src/components/Layout/Sidebar.style.ts
+++ b/src/components/Layout/Sidebar.style.ts
@@ -1,0 +1,20 @@
+import styled from "@emotion/styled";
+
+export const Profile = styled.a`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 10px 0;
+  cursor: pointer;
+`;
+
+export const UserName = styled.span`
+  ${({ theme }) => theme.typo["title-2-b"]}
+`;
+
+export const NeedLogin = styled.span`
+  ${({ theme }) => theme.typo["title-2-m"]}
+  color: ${({ theme }) => theme.colors.neutral["50"]};
+`;

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,0 +1,65 @@
+import { Cancel, ProfileCircle } from "iconoir-react";
+
+import Avatar from "../Avatar";
+import Button from "../Button";
+import Drawer from "../Drawer";
+
+import Menus from "./Menus";
+import { Profile, UserName, NeedLogin } from "./Sidebar.style";
+
+interface SidebarProps {
+  readonly isVisible: boolean;
+  readonly userName?: string;
+  readonly userImage?: string;
+  readonly onClose: () => void;
+  readonly onClickProfile: (e: React.MouseEvent) => void;
+}
+
+export default function Sidebar({
+  isVisible,
+  userName,
+  userImage,
+  onClose,
+  onClickProfile,
+}: SidebarProps) {
+  return (
+    <Drawer
+      position="right"
+      isOpen={isVisible}
+      title={
+        <Button
+          icon={<Cancel />}
+          name="메뉴 닫기"
+          styleType="text"
+          color="neutral"
+          onClick={onClose}
+        />
+      }
+      onClose={onClose}
+    >
+      <div>
+        <Profile onClick={onClickProfile}>
+          {/* 로그인 */}
+          {userName && (
+            <>
+              <Avatar
+                userName={userName ? userName : ""}
+                src={userImage}
+                size="xl"
+              />
+              <UserName>{userName}</UserName>
+            </>
+          )}
+          {/* 미로그인 */}
+          {!userName && (
+            <>
+              <ProfileCircle height={56} width={56} color="#ccc" />
+              <NeedLogin>로그인이 필요해요</NeedLogin>
+            </>
+          )}
+        </Profile>
+      </div>
+      <Menus />
+    </Drawer>
+  );
+}

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,46 +1,78 @@
 import { HomeSimple, Menu, Search, Tv } from "iconoir-react";
+import { useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 
-import BottomNavigation from "../BottomNavigation";
+import BottomNavigation, { INavigationItem } from "../BottomNavigation";
+
+import Sidebar from "./Sidebar";
+
+// 하단 네비게이션 버튼 아이템
+const bottomNavItems: INavigationItem[] = [
+  {
+    id: "/",
+    to: "/",
+    icon: <HomeSimple />,
+    label: "홈",
+  },
+  {
+    id: "/animations",
+    to: "/animations",
+    icon: <Tv />,
+    label: "애니",
+  },
+  {
+    id: "/search",
+    to: "/search",
+    icon: <Search />,
+    label: "검색",
+  },
+  {
+    id: "/menu",
+    to: "/menu",
+    icon: <Menu />,
+    label: "메뉴",
+  },
+];
 
 export default function Layout() {
+  const [isSidebarVisible, setIsSidebarVisible] = useState(false);
   const location = useLocation();
 
   const currentPath = location.pathname;
 
+  const handleSidebarVisible = (value: boolean) => {
+    setIsSidebarVisible(value);
+  };
+
+  const handleClickProfile = (e: React.MouseEvent) => {
+    e.preventDefault();
+    //TODO: 로그인 유무에 따른 라우팅 처리
+  };
+
+  const handleClickNav = (id: string) => {
+    //TODO: 로그인 유무에 따른 라우팅 처리
+    switch (id) {
+      case "/menu":
+        setIsSidebarVisible(true);
+        return;
+    }
+  };
+
   return (
     <>
       <Outlet />
+      <Sidebar
+        isVisible={isSidebarVisible}
+        // userName={}
+        // userImage={}
+        onClose={() => handleSidebarVisible(false)}
+        onClickProfile={handleClickProfile}
+      />
       <BottomNavigation
         title="모바일 네비게이션"
-        activeKey={currentPath}
-        // onClickItem={handleClickNav}
-        items={[
-          {
-            key: "/",
-            to: "/",
-            icon: <HomeSimple />,
-            label: "홈",
-          },
-          {
-            key: "/animations",
-            to: "/animations",
-            icon: <Tv />,
-            label: "애니",
-          },
-          {
-            key: "/search",
-            to: "/search",
-            icon: <Search />,
-            label: "검색",
-          },
-          {
-            key: "/menu",
-            to: "/menu",
-            icon: <Menu />,
-            label: "메뉴",
-          },
-        ]}
+        activeId={currentPath}
+        onClickItem={handleClickNav}
+        items={bottomNavItems}
       />
     </>
   );


### PR DESCRIPTION
## 📝 개요
[feat: 사용자 레이아웃의 메뉴 사이드바](https://github.com/oduck-team/oduck-client/commit/de031a33ed03eafed66af68c2e3e5a662454379d)
```
Layout 컴포넌트
|
Sidebar
|
Menus
|
Menu
```
### 미로그인
https://github.com/oduck-team/oduck-client/assets/105474635/f397cb70-462c-419c-b087-2b9f08a86a47
### 로그인
https://github.com/oduck-team/oduck-client/assets/105474635/7eea928e-1c98-4b15-8df0-d895a2b98918
### 메뉴 상호작용



https://github.com/oduck-team/oduck-client/assets/105474635/305e1cf1-4a06-4080-a726-7afd2c51fc5d



## 🚀 변경사항

[refactor: BottomNavigation 코드 스타일 변경](https://github.com/oduck-team/oduck-client/commit/4ac5118df7a786d254f7dc37f3ae36e09b714f55) https://github.com/oduck-team/oduck-client/issues/30
- props가 아닌 interface에 접두사 `I` 추가
- 객체의 프로퍼티 key -> id로 변경

[feat: Route profile 추가](https://github.com/oduck-team/oduck-client/commit/5860ea59cd613a1fa439939f2c94fe33bc0d7974)




- 로그인한 사용자의 본인 프로필로 가는 route
## 🔗 관련 이슈

#53

## ➕ 기타


