### PR TITLE
Feat: Tabs Component 구현

### DIFF
--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -1,0 +1,8 @@
+interface TabProps {
+  readonly title?: string;
+  readonly children?: React.ReactNode;
+}
+
+export function Tab({ children }: TabProps) {
+  return <div>{children}</div>;
+}

--- a/src/components/Tabs/TabTitle.styles.ts
+++ b/src/components/Tabs/TabTitle.styles.ts
@@ -1,0 +1,25 @@
+import styled from "@emotion/styled";
+
+import { StyleProps } from "./TabTitle";
+
+export const Container = styled.li<StyleProps>`
+  display: flex;
+  width: 180px;
+  padding: 14px 10px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  border-bottom: ${({ active, theme }) =>
+    active
+      ? `2px solid ${theme.colors.primary["60"]}`
+      : `2px solid ${theme.colors.neutral["10"]}`};
+
+  ${({ theme }) => theme.typo["body-2-r"]}
+  color: ${({ active, theme }) =>
+    active ? theme.colors.primary["60"] : theme.colors.neutral["50"]};
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.primary["60"]};
+  }
+`;

--- a/src/components/Tabs/TabTitle.tsx
+++ b/src/components/Tabs/TabTitle.tsx
@@ -1,0 +1,24 @@
+import { Container } from "./TabTitle.styles";
+
+export interface StyleProps {
+  readonly active: boolean;
+}
+
+interface TabTitleProps extends StyleProps {
+  readonly title?: string;
+  readonly index: number;
+  readonly setSelectedTab: (index: number) => void;
+}
+
+export default function TabTitle({
+  title,
+  index,
+  setSelectedTab,
+  active = false,
+}: TabTitleProps) {
+  return (
+    <Container active={active} onClick={() => setSelectedTab(index)}>
+      {title}
+    </Container>
+  );
+}

--- a/src/components/Tabs/Tabs.style.ts
+++ b/src/components/Tabs/Tabs.style.ts
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+
+export const TabTitles = styled.ul`
+  display: flex;
+`;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,29 @@
+import { ReactElement, useState } from "react";
+
+import { TabTitles } from "./Tabs.style";
+import TabTitle from "./TabTitle";
+
+interface TabsProps {
+  readonly children: ReactElement[];
+}
+
+export function Tabs({ children }: TabsProps) {
+  const [selectedTab, setSelectedTab] = useState(0);
+
+  return (
+    <div>
+      <TabTitles>
+        {children.map((item, index) => (
+          <TabTitle
+            key={index}
+            title={item.props.title}
+            index={index}
+            setSelectedTab={setSelectedTab}
+            active={selectedTab === index ? true : false}
+          />
+        ))}
+      </TabTitles>
+      {children[selectedTab]}
+    </div>
+  );
+}

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,0 +1,2 @@
+export * from "./Tab";
+export * from "./Tabs";


### PR DESCRIPTION
## 📝 개요


https://github.com/oduck-team/oduck-client/assets/14821702/e25afc7f-dc04-40c1-be25-6016c3858dcb

### 사용 방법

![tabs사용](https://github.com/oduck-team/oduck-client/assets/14821702/d3f4eb8d-10ea-4149-b995-1248af9d36ca)

## 🚀 변경사항

- Tabs 컴포넌트 구현
- Tab 컴포넌트 구현
- TabTitle 컴포넌트 구현

## 🔗 관련 이슈

#28 

## ➕ 기타

디자인에 Tabs의 Content 영역은 없었는데 일단 간단하게 넣어 놨습니다.