### PR TITLE
feat: Modal 컴포넌트

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,39 @@
+import { AnimatePresence } from "framer-motion";
+
+import { StrictPropsWithChildren } from "@/types";
+
+import Backdrop from "../Backdrop";
+import Portal from "../Portal";
+
+import { Container } from "./style";
+
+export type Size = "sm" | "md" | "lg" | "xl";
+
+export interface ModalProps {
+  readonly isOpened?: boolean;
+  readonly size?: Size;
+  readonly showBackdrop?: boolean;
+  readonly onClose: () => void;
+}
+
+export default function Modal({
+  isOpened = false,
+  size = "sm",
+  showBackdrop = true,
+  onClose,
+  children,
+}: StrictPropsWithChildren<ModalProps>) {
+  return (
+    <AnimatePresence>
+      {isOpened && (
+        <Portal elementId="modal-root">
+          <Backdrop isVisible={showBackdrop} onClick={onClose}>
+            <Container size={size} onClick={(e) => e.stopPropagation()}>
+              {children}
+            </Container>
+          </Backdrop>
+        </Portal>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/Modal/style.ts
+++ b/src/components/Modal/style.ts
@@ -1,0 +1,35 @@
+import { SerializedStyles, css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { motion } from "framer-motion";
+
+import { ModalProps, Size } from "./index";
+
+const sizes: Record<Size, SerializedStyles> = {
+  sm: css`
+    min-width: 240px;
+  `,
+  md: css`
+    min-width: 368px;
+  `,
+  lg: css`
+    min-width: 564px;
+  `,
+  xl: css`
+    min-width: 760px;
+  `,
+};
+
+export const Container = styled(motion.div)<Pick<ModalProps, "size">>`
+  position: fixed;
+  top: 40%;
+  border-radius: 4px;
+  background-color: white;
+  box-shadow:
+    0px 10px 32px -4px rgba(24, 39, 75, 0.1),
+    0px 6px 14px -6px rgba(24, 39, 75, 0.12);
+
+  ${({ size = "sm", theme }) => css`
+    ${sizes[size]}
+    z-dinex: ${theme.zIndex.modal}
+  `}
+`;

--- a/src/components/ModalActions/index.tsx
+++ b/src/components/ModalActions/index.tsx
@@ -1,0 +1,16 @@
+import { StrictPropsWithChildren } from "@/types";
+
+import { Container } from "./style";
+
+type Direction = "row" | "col";
+
+export interface ModalActionsProps {
+  readonly direction?: Direction; // 정렬 방향
+}
+
+export default function ModalActions({
+  direction = "row",
+  children,
+}: StrictPropsWithChildren<ModalActionsProps>) {
+  return <Container direction={direction}>{children}</Container>;
+}

--- a/src/components/ModalActions/style.ts
+++ b/src/components/ModalActions/style.ts
@@ -1,0 +1,14 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+
+import { ModalActionsProps } from ".";
+
+export const Container = styled.div<Pick<ModalActionsProps, "direction">>`
+  display: flex;
+  gap: 8px;
+  padding: 8px 16px 16px 16px;
+
+  ${({ direction = "row" }) => css`
+    flex-direction: ${direction === "row" ? "row" : "column"};
+  `}
+`;

--- a/src/components/ModalContent/index.tsx
+++ b/src/components/ModalContent/index.tsx
@@ -1,0 +1,7 @@
+import { StrictPropsWithChildren } from "@/types";
+
+import { Container } from "./style";
+
+export default function ModalContent({ children }: StrictPropsWithChildren) {
+  return <Container>{children}</Container>;
+}

--- a/src/components/ModalContent/style.ts
+++ b/src/components/ModalContent/style.ts
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  padding: 16px 24px 12px 24px;
+`;


### PR DESCRIPTION
## 📝 개요
깰꼼스한 모달 컴포넌트를 구현 함
### 구조
```
Modal
|
|_ModalContent
|
|_ModalActions
```
### 사용예
```html
<Modal isOpened={o} size="md" onClose={hanldeCloseModal}>
  <ModalContent>모달 내용입니다</ModalContent>
  <ModalActions>
    <Button name="닫기" styleType="text" color="neutral" isBlock>
      닫기
    </Button>
    <Button name="확인" isBlock>
      확인
    </Button>
  </ModalActions>
</Modal>
```

https://github.com/oduck-team/oduck-client/assets/105474635/c1dec44a-9f2a-43d5-9e27-80e2eadc0692

prop으로 size를 넘겨 가로 넓이를 바꿀수 있음 ( sm, md, lg, xl )
<img width="1080" alt="스크린샷 2023-08-21 오후 10 53 21" src="https://github.com/oduck-team/oduck-client/assets/105474635/848e7d01-e4d9-4037-9a31-68e14fb283d8">



## 🚀 변경사항



## 🔗 관련 이슈
#45

## ➕ 기타
- 코드 스타일 확인 부탁드립니다!
- framer-motion은 신이에요

