### PR TITLE
feat: React lazy 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,9 @@
 import { ThemeProvider } from "@emotion/react";
 import { IconoirProvider } from "iconoir-react";
 import { HelmetProvider } from "react-helmet-async";
-import { Routes, Route } from "react-router-dom";
+import { RouterProvider } from "react-router-dom";
 
-import Layout from "./components/Layout";
-import AdminLayout from "./features/admin/components/Layout";
-import Dashboard from "./features/admin/routes/Dashboard";
-import AnimationDetail from "./features/animations/routes/Detail";
-import AnimationList from "./features/animations/routes/List";
-import Login from "./features/auth/routes/Login";
-import NotFound from "./features/common/routes/404";
-import HelpDesk from "./features/common/routes/HelpDesk";
-import Home from "./features/common/routes/Home";
-import Search from "./features/common/routes/Search";
-import UserProfile from "./features/users/routes/Profile";
+import router from "./routes";
 import { theme } from "./styles/theme";
 
 export default function App() {
@@ -25,23 +15,7 @@ export default function App() {
             strokeWidth: 1.5,
           }}
         >
-          <Routes>
-            <Route path="/login" element={<Login />} />
-            <Route path="/" element={<Layout />}>
-              <Route index path="" element={<Home />} />
-              <Route path="/animations" element={<AnimationList />} />
-              <Route path="/animations/:id" element={<AnimationDetail />} />
-              <Route path="/search" element={<Search />} />
-              <Route path="/helpdesk" element={<HelpDesk />} />
-              {/* TODO: 인증 */}
-              <Route path="/users/:id" element={<UserProfile />} />
-              <Route path="/profile" element={<UserProfile />} />
-            </Route>
-            <Route path="/admin" element={<AdminLayout />}>
-              <Route path="" element={<Dashboard />} />
-            </Route>
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+          <RouterProvider router={router} />
         </IconoirProvider>
       </ThemeProvider>
     </HelmetProvider>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,5 +1,5 @@
 import { HomeSimple, Menu, Search, Tv } from "iconoir-react";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import BottomNavigation, { INavigationItem } from "../BottomNavigation";
@@ -74,20 +74,22 @@ export default function Layout() {
 
   return (
     <>
-      <Outlet />
-      <Sidebar
-        isVisible={isSidebarVisible}
-        // userName={}
-        // userImage={}
-        onClose={() => handleSidebarVisible(false)}
-        onClickProfile={handleClickProfile}
-      />
-      <BottomNavigation
-        title="모바일 네비게이션"
-        activeId={currentPath}
-        onClickItem={handleClickNav}
-        items={bottomNavItems}
-      />
+      <Suspense fallback={"loading"}>
+        <Outlet />
+        <Sidebar
+          isVisible={isSidebarVisible}
+          // userName={}
+          // userImage={}
+          onClose={() => handleSidebarVisible(false)}
+          onClickProfile={handleClickProfile}
+        />
+        <BottomNavigation
+          title="모바일 네비게이션"
+          activeId={currentPath}
+          onClickItem={handleClickNav}
+          items={bottomNavItems}
+        />
+      </Suspense>
     </>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
 
 import App from "./App.tsx";
 
@@ -8,8 +7,6 @@ import "./assets/style.css";
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <App />
   </React.StrictMode>,
 );

--- a/src/routes/adminRoutes.tsx
+++ b/src/routes/adminRoutes.tsx
@@ -1,0 +1,29 @@
+import { lazy } from "react";
+import { RouteObject } from "react-router-dom";
+
+import { StrictPropsWithChildren } from "@/types";
+
+const Layout = lazy(() => import("@/features/admin/components/Layout"));
+const Dashboard = lazy(() => import("@/features/admin/routes/Dashboard"));
+
+function AdminRoute({ children }: StrictPropsWithChildren) {
+  // TODO: ADMIN ROLE 확인
+  return children;
+}
+
+export const adminRoutes: RouteObject[] = [
+  {
+    path: "/admin",
+    element: (
+      <AdminRoute>
+        <Layout />
+      </AdminRoute>
+    ),
+    children: [
+      {
+        path: "",
+        element: <Dashboard />,
+      },
+    ],
+  },
+];

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,13 @@
+import { createBrowserRouter } from "react-router-dom";
+
+import { adminRoutes } from "./adminRoutes";
+import { privateRoutes } from "./privateRoutes";
+import { publicRoutes } from "./publicRoutes";
+
+const router = createBrowserRouter([
+  ...adminRoutes,
+  ...privateRoutes,
+  ...publicRoutes,
+]);
+
+export default router;

--- a/src/routes/privateRoutes.tsx
+++ b/src/routes/privateRoutes.tsx
@@ -1,0 +1,10 @@
+import { RouteObject } from "react-router-dom";
+
+import { StrictPropsWithChildren } from "@/types";
+
+function PrivateRoute({ children }: StrictPropsWithChildren) {
+  // TODO: USER ROLE 확인
+  return children;
+}
+
+export const privateRoutes: RouteObject[] = [];

--- a/src/routes/publicRoutes.tsx
+++ b/src/routes/publicRoutes.tsx
@@ -1,0 +1,60 @@
+import { lazy } from "react";
+import { RouteObject } from "react-router-dom";
+
+import Layout from "@/components/Layout";
+import Login from "@/features/auth/routes/Login";
+import Home from "@/features/common/routes/Home";
+
+const AnimationList = lazy(() => import("@/features/animations/routes/List"));
+const AnimationDetail = lazy(
+  () => import("@/features/animations/routes/Detail"),
+);
+const Search = lazy(() => import("@/features/common/routes/Search"));
+const HelpDesk = lazy(() => import("@/features/common/routes/HelpDesk"));
+const Profile = lazy(() => import("@/features/common/routes/Search"));
+const NotFound = lazy(() => import("@/features/common/routes/404"));
+
+export const publicRoutes: RouteObject[] = [
+  {
+    path: "/login",
+    element: <Login />,
+  },
+  {
+    path: "/",
+    element: <Layout />,
+    children: [
+      {
+        path: "",
+        element: <Home />,
+      },
+      {
+        path: "/animations",
+        element: <AnimationList />,
+      },
+      {
+        path: "/animations/:id",
+        element: <AnimationDetail />,
+      },
+      {
+        path: "/search",
+        element: <Search />,
+      },
+      {
+        path: "/helpdesk",
+        element: <HelpDesk />,
+      },
+      {
+        path: "/users/:id",
+        element: <Profile />,
+      },
+      {
+        path: "/profile",
+        element: <Profile />,
+      },
+    ],
+  },
+  {
+    path: "*",
+    element: <NotFound />,
+  },
+];

--- a/src/routes/publicRoutes.tsx
+++ b/src/routes/publicRoutes.tsx
@@ -11,7 +11,7 @@ const AnimationDetail = lazy(
 );
 const Search = lazy(() => import("@/features/common/routes/Search"));
 const HelpDesk = lazy(() => import("@/features/common/routes/HelpDesk"));
-const Profile = lazy(() => import("@/features/common/routes/Search"));
+const Profile = lazy(() => import("@/features/users/routes/Profile"));
 const NotFound = lazy(() => import("@/features/common/routes/404"));
 
 export const publicRoutes: RouteObject[] = [


### PR DESCRIPTION
## 📝 개요
Home, Login 화면을 제외한 화면에 lazy를 적용했습니다

### 적용전 Home 요청

<img width="659" alt="스크린샷 2023-08-22 오후 12 14 07" src="https://github.com/oduck-team/oduck-client/assets/105474635/a1fc811b-83b8-4632-8a21-b21ffcc83695">

### 적용후 Home 요청

<img width="659" alt="스크린샷 2023-08-22 오후 12 12 28" src="https://github.com/oduck-team/oduck-client/assets/105474635/d4153631-1d7c-42b9-a3ba-09247bc63734">

## 🚀 변경사항

react-router 적용 방식은 lazy를 지원하는 [data api](https://reactrouter.com/en/main/routers/picking-a-router#using-v64-data-apis)로 변경했습니다

## 🔗 관련 이슈

#54

## ➕ 기타



