### PR TITLE
refactor: Stat 컴포넌트 Content의 min-width -> width: fit-content 변경

### DIFF
--- a/src/components/Stat/style.ts
+++ b/src/components/Stat/style.ts
@@ -36,7 +36,7 @@ export const Divider = styled.div`
 `;
 
 export const Content = styled.div`
-  min-width: 72px;
+  width: fit-content;
   display: flex;
   flex-direction: column;
   text-align: center;


### PR DESCRIPTION
## 📝 개요

Stat 컴포넌트에 min-width가 설정되어 있어 특정 width 이하로 줄지 않는 문제점이 발생

## 🚀 변경사항

Content에서 min-width: 72px를 width: fit-content로 변경

## 🔗 관련 이슈

#31

## ➕ 기타