### PR TITLE
style: 사용자 메뉴 Drawer 링크 폰트 사이즈 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider } from "@emotion/react";
+import { ThemeProvider, Global, css } from "@emotion/react";
 import { IconoirProvider } from "iconoir-react";
 import { HelmetProvider } from "react-helmet-async";
 import { RouterProvider } from "react-router-dom";
@@ -15,6 +15,13 @@ export default function App() {
             strokeWidth: 1.5,
           }}
         >
+          <Global
+            styles={css`
+              body {
+                color: ${theme.colors.neutral["90"]};
+              }
+            `}
+          />
           <RouterProvider router={router} />
         </IconoirProvider>
       </ThemeProvider>

--- a/src/components/Layout/Menu.style.ts
+++ b/src/components/Layout/Menu.style.ts
@@ -12,6 +12,7 @@ export const Container = styled.li`
   }
 
   & > a {
+    ${({ theme }) => theme.typo["body-2-m"]}
     display: flex;
     align-items: center;
     gap: 0.5rem;


### PR DESCRIPTION
## 📝 개요


<img width="403" alt="스크린샷 2023-08-25 오전 11 53 53" src="https://github.com/oduck-team/oduck-client/assets/105474635/e1957d6d-aa7c-454e-b288-93c8a69b1bc0">

16px -> 14px로 반영 완료

## 🚀 변경사항

body 태그에 모든 폰트 기본색 neutral-90 적용 [sytle: 전역 폰트 색](https://github.com/oduck-team/oduck-client/commit/00431fb01eaebb78b62d5768712d13030fa53bbf) https://github.com/oduck-team/oduck-client/issues/3

## 🔗 관련 이슈

#53 #3

## ➕ 기타



