### PR TITLE
feat: 애니메이션 리스트 페이지 퍼블리싱

### DIFF
--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -81,6 +81,7 @@ export default function BottomSheet({
               animate="visible"
               exit="exit"
               variants={variants}
+              onClick={(e) => e.stopPropagation()}
             >
               {header && (
                 <Header>

--- a/src/components/BottomSheet/style.ts
+++ b/src/components/BottomSheet/style.ts
@@ -49,6 +49,12 @@ export const Header = styled.div`
 
 export const Content = styled.div`
   overflow-y: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export const Footer = styled.div`

--- a/src/components/Chip/ActionChip.style.ts
+++ b/src/components/Chip/ActionChip.style.ts
@@ -1,8 +1,25 @@
+import { SerializedStyles, css } from "@emotion/react";
 import styled from "@emotion/styled";
 
-export const Container = styled.button`
+import { ActionChipProps } from "./ActionChip";
+
+import { ChipSize } from ".";
+
+export const Sizes: Record<ChipSize, SerializedStyles> = {
+  sm: css`
+    height: 28px;
+  `,
+  md: css`
+    height: 32px;
+  `,
+  lg: css`
+    height: 36px;
+  `,
+};
+
+export const Container = styled.button<ActionChipProps>`
   width: fit-content;
-  height: 32px;
+  ${({ size = "md" }) => Sizes[size]}
   padding: 8px 16px;
   display: inline-flex;
   justify-content: center;

--- a/src/components/Chip/ActionChip.tsx
+++ b/src/components/Chip/ActionChip.tsx
@@ -2,13 +2,20 @@ import { ComponentProps } from "react";
 
 import { Container } from "./ActionChip.style";
 
+import { ChipSize } from ".";
+
+export interface ActionChipProps extends ComponentProps<"button"> {
+  size: ChipSize;
+}
+
 export default function ActionChip({
+  size,
   className,
   children,
   onClick,
-}: ComponentProps<"button">) {
+}: ActionChipProps) {
   return (
-    <Container className={className} onClick={onClick}>
+    <Container size={size} className={className} onClick={onClick}>
       {children}
     </Container>
   );

--- a/src/components/Chip/FilterChip.style.ts
+++ b/src/components/Chip/FilterChip.style.ts
@@ -1,10 +1,12 @@
 import styled from "@emotion/styled";
 
+import { Sizes } from "./ActionChip.style";
+
 import { ChipProps } from ".";
 
 export const Container = styled.button<Omit<ChipProps, "styleType">>`
   width: fit-content;
-  height: 32px;
+  ${({ size = "md" }) => Sizes[size]}
   padding: 8px 16px;
   display: inline-flex;
   justify-content: center;
@@ -21,6 +23,7 @@ export const Container = styled.button<Omit<ChipProps, "styleType">>`
   ${({ active }) => active && `font-weight: 700`};
   letter-spacing: normal;
   cursor: pointer;
+  flex-shrink: 0;
 
   & > svg {
     width: 16px;

--- a/src/components/Chip/FilterChip.tsx
+++ b/src/components/Chip/FilterChip.tsx
@@ -3,6 +3,7 @@ import { Container } from "./FilterChip.style";
 import { ChipProps } from ".";
 
 export default function FilterChip({
+  size,
   active = false,
   icon,
   className,
@@ -11,6 +12,7 @@ export default function FilterChip({
 }: Omit<ChipProps, "styleType">) {
   return (
     <Container
+      size={size}
       active={active}
       icon={icon}
       className={className}

--- a/src/components/Chip/SelectableChip.style.ts
+++ b/src/components/Chip/SelectableChip.style.ts
@@ -1,10 +1,12 @@
 import styled from "@emotion/styled";
 
+import { Sizes } from "./ActionChip.style";
+
 import { ChipProps } from ".";
 
 export const Container = styled.button<Omit<ChipProps, "styleType" | "icon">>`
   width: fit-content;
-  height: 28px;
+  ${({ size = "md" }) => Sizes[size]}
   padding: 6px 10px;
   display: inline-flex;
   justify-content: center;

--- a/src/components/Chip/SelectableChip.tsx
+++ b/src/components/Chip/SelectableChip.tsx
@@ -3,13 +3,19 @@ import { Container } from "./SelectableChip.style";
 import { ChipProps } from ".";
 
 export default function SelectableChip({
+  size,
   active = false,
   className,
   children,
   onClick,
 }: Omit<ChipProps, "styleType" | "icon">) {
   return (
-    <Container className={className} active={active} onClick={onClick}>
+    <Container
+      size={size}
+      active={active}
+      className={className}
+      onClick={onClick}
+    >
       {children}
     </Container>
   );

--- a/src/components/Chip/index.tsx
+++ b/src/components/Chip/index.tsx
@@ -5,30 +5,39 @@ import FilterChip from "./FilterChip";
 import SelectableChip from "./SelectableChip";
 
 export type ChipType = "action" | "selectable" | "filter";
+export type ChipSize = "sm" | "md" | "lg";
 
 export interface ChipProps extends ComponentProps<"button"> {
   styleType?: ChipType;
   active?: boolean;
   icon?: React.ReactNode;
+  size?: ChipSize;
 }
 // TODO: size를 옵션으로 받기
 export default function Chip({
   styleType = "action",
   active,
   icon,
+  size = "md",
   className,
   children,
   onClick,
 }: ChipProps) {
   if (styleType === "selectable")
     return (
-      <SelectableChip active={active} onClick={onClick} className={className}>
+      <SelectableChip
+        size={size}
+        active={active}
+        onClick={onClick}
+        className={className}
+      >
         {children}
       </SelectableChip>
     );
   else if (styleType === "filter")
     return (
       <FilterChip
+        size={size}
         active={active}
         icon={icon}
         onClick={onClick}
@@ -39,7 +48,7 @@ export default function Chip({
     );
 
   return (
-    <ActionChip onClick={onClick} className={className}>
+    <ActionChip size={size} onClick={onClick} className={className}>
       {children}
     </ActionChip>
   );

--- a/src/features/animations/components/AnimationCard.style.ts
+++ b/src/features/animations/components/AnimationCard.style.ts
@@ -1,10 +1,16 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
-import { Animation } from "./AnimationCarousel";
+interface CardProps {
+  size?: "md" | "lg";
+}
 
-export const Container = styled.div`
-  width: 160px;
+interface ImageProps extends CardProps {
+  image: string;
+}
+
+export const Container = styled.div<CardProps>`
+  width: ${({ size = "md" }) => (size === "md" ? `160px` : `100%`)};
   flex-shrink: 0;
   & > a {
     display: flex;
@@ -14,9 +20,9 @@ export const Container = styled.div`
   }
 `;
 
-export const Image = styled.div<Pick<Animation, "image">>`
+export const Image = styled.div<ImageProps>`
   width: 100%;
-  height: 110px;
+  height: ${({ size = "md" }) => (size === "md" ? `110px` : `152px`)};
   border-radius: 5px;
   ${({ image }) => css`
     background:
@@ -27,9 +33,9 @@ export const Image = styled.div<Pick<Animation, "image">>`
   background-position: center;
 `;
 
-export const InfoContainer = styled.div`
+export const InfoContainer = styled.div<CardProps>`
   width: 100%;
-  height: 65px;
+  height: ${({ size = "md" }) => (size === "md" ? `65px` : `fit-content`)};
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/features/animations/components/AnimationCard.tsx
+++ b/src/features/animations/components/AnimationCard.tsx
@@ -12,14 +12,16 @@ import { Animation } from "./AnimationCarousel";
 
 export default function AnimationCard({
   ani,
+  size,
 }: {
   ani: Omit<Animation, "review">;
+  size?: "md" | "lg";
 }) {
   return (
-    <Container>
+    <Container size={size}>
       <Link to={`/animations/${ani.id}`}>
-        <Image image={ani.image} />
-        <InfoContainer>
+        <Image image={ani.image} size={size} />
+        <InfoContainer size={size}>
           <Title>{ani.title}</Title>
           <Rating>
             <Star />

--- a/src/features/animations/routes/List.tsx
+++ b/src/features/animations/routes/List.tsx
@@ -1,3 +1,330 @@
+import styled from "@emotion/styled";
+import { Cancel, Filter, NavArrowLeft } from "iconoir-react";
+import { useState } from "react";
+
+import BottomSheet from "@/components/BottomSheet";
+import Button from "@/components/Button";
+import Chip from "@/components/Chip";
+import Tabs from "@/components/Tabs";
+
+import AnimationCard from "../components/AnimationCard";
+import { Animation } from "../components/AnimationCarousel";
+
 export default function AnimationList() {
-  return <div>애니메이션 목록</div>;
+  const [bottomSheetOpen, setBottomSheetOpen] = useState(false);
+
+  const [filtered, setFiltered] = useState<string[]>([]);
+
+  const items = [
+    {
+      id: 1,
+      title: "최신순",
+      url: "/animations",
+    },
+    {
+      id: 2,
+      title: "리뷰순",
+      url: "?sort=review",
+    },
+    {
+      id: 3,
+      title: "평점순",
+      url: "?sort=rating",
+    },
+  ];
+
+  const CardAni: Omit<Animation, "review"> = {
+    id: "234567",
+    title: "원피스",
+    image: "https://url.kr/2y9rgl",
+    rating: 4.8,
+  };
+  const CardAni2: Omit<Animation, "review"> = {
+    id: "234568",
+    title:
+      "레벨 1이지만 유니크 스킬로 최강이 되었습니다 레벨 1이지만 유니크 스킬로 최강이 되었습니다",
+    image: "https://url.kr/2y9rgl",
+    rating: 4.5,
+  };
+
+  const genres = [
+    "판타지",
+    "로맨스",
+    "액션",
+    "가족",
+    "이세계",
+    "개그",
+    "학원",
+    "감동",
+    "범죄",
+    "SF",
+    "드라마",
+  ];
+
+  const seasons = [
+    "2023년 1분기",
+    "2023년 2분기",
+    "2023년 3분기",
+    "2023년 4분기",
+    "2022년",
+    "2021년",
+    "2020년",
+    "2019년",
+    "2018년",
+    "2017년",
+    "2010년대",
+    "2000년대",
+    "2000년대 이전",
+  ];
+
+  const broadcastTypes = ["TVA", "OVA", "극장판"];
+
+  const statuses = ["방영중", "완결"];
+
+  const episodeNumber = [
+    "12화 이하",
+    "24화 이하",
+    "48화 이하",
+    "100화 이하",
+    "100화 이상",
+  ];
+
+  const handlerOptionClick = (item: string) => {
+    if (filtered.includes(item))
+      setFiltered([...filtered].filter((a) => a !== item));
+    else setFiltered([...filtered, item]);
+  };
+
+  const resetFilter = () => {
+    setFiltered([]);
+  };
+
+  const handlerCloseClick = () => {
+    resetFilter();
+    setBottomSheetOpen(false);
+  };
+
+  const handlerOkClick = () => {
+    // TODO 필터링된 애니 요청
+    // BottomSheet 닫기
+  };
+
+  return (
+    <Container>
+      <div style={{ width: "100%", position: "fixed", left: "0" }}>
+        <Header>
+          <NavArrowLeft />
+          애니
+          <Filter onClick={() => setBottomSheetOpen(true)} />
+        </Header>
+        <Tabs items={items} defaultActiveId={1} />
+      </div>
+      <Content>
+        <AnimationCard size="lg" ani={CardAni} />
+        <AnimationCard size="lg" ani={CardAni2} />
+        <AnimationCard size="lg" ani={CardAni} />
+        <AnimationCard size="lg" ani={CardAni2} />
+      </Content>
+      <BottomSheet
+        isOpen={bottomSheetOpen}
+        onClose={() => setBottomSheetOpen(false)}
+        footer={
+          <OkButton
+            name="적용 완료"
+            size="lg"
+            style={{ width: "100%" }}
+            onClick={handlerOkClick}
+          >
+            적용 완료
+          </OkButton>
+        }
+      >
+        <FilterContainer>
+          <Cancel width={24} height={24} onClick={handlerCloseClick} />
+          {filtered.length > 0 && (
+            <ChipsContiner style={{ marginBottom: "24px" }}>
+              <h3 style={{ marginTop: "0" }}>
+                선택된 필터
+                <Button
+                  styleType="text"
+                  size="sm"
+                  name="초기화"
+                  onClick={resetFilter}
+                >
+                  초기화
+                </Button>
+              </h3>
+              <Chips>
+                {filtered.map((item, i) => (
+                  <Chip
+                    key={i}
+                    active={filtered.includes(item)}
+                    styleType="filter"
+                    size="lg"
+                    onClick={() => handlerOptionClick(item)}
+                    icon={<Cancel />}
+                  >
+                    {item}
+                  </Chip>
+                ))}
+              </Chips>
+            </ChipsContiner>
+          )}
+          <ChipsContiner>
+            <h3 style={{ marginTop: "0" }}>장르</h3>
+            <Chips>
+              {genres.map((genre, i) => (
+                <Chip
+                  key={i}
+                  active={filtered.includes(genre)}
+                  styleType="filter"
+                  size="lg"
+                  onClick={() => handlerOptionClick(genre)}
+                >
+                  {genre}
+                </Chip>
+              ))}
+            </Chips>
+          </ChipsContiner>
+          <ChipsContiner>
+            <h3>출시년도</h3>
+            <Chips>
+              {seasons.map((season, i) => (
+                <Chip
+                  key={i}
+                  active={filtered.includes(season)}
+                  styleType="filter"
+                  size="lg"
+                  onClick={() => handlerOptionClick(season)}
+                >
+                  {season}
+                </Chip>
+              ))}
+            </Chips>
+          </ChipsContiner>
+          <ChipsContiner>
+            <h3>방영타입</h3>
+            <Chips>
+              {broadcastTypes.map((type, i) => (
+                <Chip
+                  key={i}
+                  active={filtered.includes(type)}
+                  styleType="filter"
+                  size="lg"
+                  onClick={() => handlerOptionClick(type)}
+                >
+                  {type}
+                </Chip>
+              ))}
+            </Chips>
+          </ChipsContiner>
+          <ChipsContiner>
+            <h3>방영</h3>
+            <Chips>
+              {statuses.map((status, i) => (
+                <Chip
+                  key={i}
+                  active={filtered.includes(status)}
+                  styleType="filter"
+                  size="lg"
+                  onClick={() => handlerOptionClick(status)}
+                >
+                  {status}
+                </Chip>
+              ))}
+            </Chips>
+          </ChipsContiner>
+          <ChipsContiner>
+            <h3>화수</h3>
+            <Chips>
+              {episodeNumber.map((num, i) => (
+                <Chip
+                  key={i}
+                  active={filtered.includes(num)}
+                  styleType="filter"
+                  size="lg"
+                  onClick={() => handlerOptionClick(num)}
+                >
+                  {num}
+                </Chip>
+              ))}
+            </Chips>
+          </ChipsContiner>
+        </FilterContainer>
+      </BottomSheet>
+    </Container>
+  );
 }
+
+const Container = styled.div`
+  background-color: white;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 66px;
+`;
+const Header = styled.div`
+  background-color: white;
+  width: 100%;
+  height: 90px;
+  padding: 40px 16px 0;
+  flex-shrink: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  ${({ theme }) => theme.typo["title-3-b"]};
+
+  & > svg {
+    width: 24px;
+    height: 24px;
+  }
+`;
+
+const Content = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 166px 16px 92px;
+`;
+
+const FilterContainer = styled.div`
+  position: relative;
+  & > svg {
+    position: fixed;
+    top: 32px;
+    right: 24px;
+    z-index: ${({ theme }) => theme.zIndex.bottomSheet + 1};
+  }
+`;
+
+const ChipsContiner = styled.div`
+  position: relative;
+  h3 {
+    ${({ theme }) => theme.typo["body-1-m"]};
+    margin: 24px 0 12px;
+    display: flex;
+    align-items: center;
+
+    button {
+      ${({ theme }) => theme.typo["body-3-r"]};
+      color: ${({ theme }) => theme.colors["neutral"]["50"]};
+      letter-spacing: normal;
+      margin-left: 3px;
+    }
+  }
+`;
+
+const Chips = styled.div`
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const OkButton = styled(Button)`
+  span {
+    ${({ theme }) => theme.typo["title-3-m"]};
+  }
+`;

--- a/src/features/animations/routes/List.tsx
+++ b/src/features/animations/routes/List.tsx
@@ -129,38 +129,33 @@ export default function AnimationList() {
         isOpen={bottomSheetOpen}
         onClose={() => setBottomSheetOpen(false)}
         footer={
-          <OkButton
-            name="적용 완료"
-            size="lg"
-            style={{ width: "100%" }}
-            onClick={handlerOkClick}
-          >
-            적용 완료
-          </OkButton>
+          <Footer>
+            <ResetButton
+              styleType="text"
+              size="sm"
+              name="초기화"
+              onClick={resetFilter}
+              color="neutral"
+            >
+              필터 초기화
+            </ResetButton>
+            <OkButton name="적용 완료" size="lg" onClick={handlerOkClick}>
+              적용 완료
+            </OkButton>
+          </Footer>
         }
       >
         <FilterContainer>
           <Cancel width={24} height={24} onClick={handlerCloseClick} />
           {filtered.length > 0 && (
             <ChipsContiner style={{ marginBottom: "24px" }}>
-              <h3 style={{ marginTop: "0" }}>
-                선택된 필터
-                <Button
-                  styleType="text"
-                  size="sm"
-                  name="초기화"
-                  onClick={resetFilter}
-                >
-                  초기화
-                </Button>
-              </h3>
+              <h3 style={{ marginTop: "0" }}>선택된 필터</h3>
               <Chips>
                 {filtered.map((item, i) => (
                   <Chip
                     key={i}
                     active={filtered.includes(item)}
                     styleType="filter"
-                    size="lg"
                     onClick={() => handlerOptionClick(item)}
                     icon={<Cancel />}
                   >
@@ -178,7 +173,6 @@ export default function AnimationList() {
                   key={i}
                   active={filtered.includes(genre)}
                   styleType="filter"
-                  size="lg"
                   onClick={() => handlerOptionClick(genre)}
                 >
                   {genre}
@@ -194,7 +188,6 @@ export default function AnimationList() {
                   key={i}
                   active={filtered.includes(season)}
                   styleType="filter"
-                  size="lg"
                   onClick={() => handlerOptionClick(season)}
                 >
                   {season}
@@ -210,7 +203,6 @@ export default function AnimationList() {
                   key={i}
                   active={filtered.includes(type)}
                   styleType="filter"
-                  size="lg"
                   onClick={() => handlerOptionClick(type)}
                 >
                   {type}
@@ -226,7 +218,6 @@ export default function AnimationList() {
                   key={i}
                   active={filtered.includes(status)}
                   styleType="filter"
-                  size="lg"
                   onClick={() => handlerOptionClick(status)}
                 >
                   {status}
@@ -242,7 +233,7 @@ export default function AnimationList() {
                   key={i}
                   active={filtered.includes(num)}
                   styleType="filter"
-                  size="lg"
+                  // size="lg"
                   onClick={() => handlerOptionClick(num)}
                 >
                   {num}
@@ -304,27 +295,37 @@ const ChipsContiner = styled.div`
   position: relative;
   h3 {
     ${({ theme }) => theme.typo["body-1-m"]};
-    margin: 24px 0 12px;
+    margin: 24px 0 8px;
     display: flex;
     align-items: center;
-
-    button {
-      ${({ theme }) => theme.typo["body-3-r"]};
-      color: ${({ theme }) => theme.colors["neutral"]["50"]};
-      letter-spacing: normal;
-      margin-left: 3px;
-    }
   }
 `;
 
 const Chips = styled.div`
   display: flex;
-  gap: 8px;
+  gap: 8px 4px;
   flex-wrap: wrap;
 `;
 
+const Footer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 40px;
+  button {
+    flex-shrink: 0;
+  }
+`;
+
 const OkButton = styled(Button)`
+  width: 208px;
   span {
     ${({ theme }) => theme.typo["title-3-m"]};
   }
+`;
+
+const ResetButton = styled(Button)`
+  padding: 0;
+  color: ${({ theme }) => theme.colors["neutral"]["50"]};
 `;


### PR DESCRIPTION
## 📝 개요

애니메이션 리스트 페이지 퍼블리싱



https://github.com/oduck-team/oduck-client/assets/80813703/b22ed69e-931c-4f25-a39f-f41edc2817fe




## 🚀 변경사항

- BottomSheet 이벤트 전파 방지 추가, 스크롤 안 보이게 함
- Chip size props 추가
- Animation Card size props 추가

## 🔗 관련 이슈

#20 #32 #85

## ➕ 기타

- 상단에 아이콘과 '애니' 있는 Header 부분 세로 길이와 그 위에 여백이 크기를 정확하게 잘 모르겠어서 임의로 설정했습니다.
- 애니메이션 Content 부분에만 스크롤을 넣으니까 조금 이상한가 싶어서 일단 윗부분(헤더+탭)을 fix하는 방향으로 스타일 설정을 해보았습니다.
- 탭 눌렀을 때 api 요청을 어떻게 처리하면 좋을지 의견을 듣고 싶습니다. 현재는 클릭 시 ?sort=review, ?sort=rating(임시)와 같이 url 변경이 일어나도록 하고, useEffect의 dependency에 query를 넣어 각 sort 옵션에 대한 요청을 하는 식으로 방향을 잡았습니다. 이대로 갈지, 각 Tab Item에 api 요청을 하는 함수를 click 이벤트로 아예 넘길 수 있도록 하게 할지 아니면 또 다른 좋은 방식이 있을지 고민이 되는데 어떻게 하면 좋을까요?-?

- 추후 api 요청 추가와 함께 코드 리팩토링 예정
