### PR TITLE
refactor: prop readonly 제거

### DIFF
--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -3,9 +3,9 @@ import { Container, UserImage, UserName } from "./style";
 export type Size = "xl" | "lg" | "md" | "sm";
 
 export interface AvatarProps {
-  readonly userName: string;
-  readonly src?: string;
-  readonly size?: Size;
+  userName: string;
+  src?: string;
+  size?: Size;
 }
 
 export default function Avatar({ userName, src, size = "md" }: AvatarProps) {

--- a/src/components/Backdrop/index.tsx
+++ b/src/components/Backdrop/index.tsx
@@ -10,9 +10,9 @@ const variants: Variants = {
 };
 
 export interface BackdropProps {
-  readonly isVisible?: boolean;
-  readonly className?: string;
-  readonly onClick: () => void;
+  isVisible?: boolean;
+  className?: string;
+  onClick: () => void;
 }
 
 export default function Backdrop({

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -8,11 +8,11 @@ type BadgeStyle = "fill" | "inverted";
 type BadgeColor = keyof typeof theme.colors;
 
 export interface BadgeProps extends ComponentProps<"span"> {
-  readonly isDot?: boolean;
-  readonly styleType?: BadgeStyle;
-  readonly color?: BadgeColor;
-  readonly count?: number;
-  readonly overflowCount?: number;
+  isDot?: boolean;
+  styleType?: BadgeStyle;
+  color?: BadgeColor;
+  count?: number;
+  overflowCount?: number;
 }
 
 export default function Badge({

--- a/src/components/BottomNavigation/index.tsx
+++ b/src/components/BottomNavigation/index.tsx
@@ -1,17 +1,17 @@
 import { Container, Item } from "./style";
 
 export interface INavigationItem {
-  readonly id: string;
-  readonly to: string;
-  readonly icon: React.ReactNode;
-  readonly label: React.ReactNode;
+  id: string;
+  to: string;
+  icon: React.ReactNode;
+  label: React.ReactNode;
 }
 
 interface BottomNavigationProps {
-  readonly title: string;
-  readonly activeId?: string; // 활성화(선택된) item의 id
-  readonly items: INavigationItem[];
-  readonly onClickItem: (id: string, e: React.MouseEvent) => void;
+  title: string;
+  activeId?: string; // 활성화(선택된) item의 id
+  items: INavigationItem[];
+  onClickItem: (id: string, e: React.MouseEvent) => void;
 }
 
 export default function BottomNavigation({

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -35,15 +35,15 @@ const variants = {
 };
 
 export interface BottomSheetProps {
-  readonly isOpen?: boolean;
-  readonly showBackdrop?: boolean;
-  readonly header?: {
+  isOpen?: boolean;
+  showBackdrop?: boolean;
+  header?: {
     left?: React.ReactNode;
     title?: string;
     right?: React.ReactNode;
   };
-  readonly footer?: React.ReactNode;
-  readonly onClose: () => void;
+  footer?: React.ReactNode;
+  onClose: () => void;
 }
 
 export default function BottomSheet({

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -10,12 +10,12 @@ type ColorKeys = "primary" | "neutral" | "warn";
 export type Size = "xl" | "lg" | "md" | "sm";
 
 export interface ButtonProps extends ComponentProps<"button"> {
-  readonly name: string;
-  readonly styleType?: Style;
-  readonly color?: Color;
-  readonly size?: Size;
-  readonly isBlock?: boolean;
-  readonly icon?: React.ReactNode;
+  name: string;
+  styleType?: Style;
+  color?: Color;
+  size?: Size;
+  isBlock?: boolean;
+  icon?: React.ReactNode;
 }
 
 export default function Button({

--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -5,13 +5,13 @@ import { Container } from "./style";
 export type Size = "lg" | "md";
 
 export interface StyleProps {
-  readonly size?: Size;
-  readonly checked?: boolean;
-  readonly disabled?: boolean;
+  size?: Size;
+  checked?: boolean;
+  disabled?: boolean;
 }
 
 interface CheckBoxProps extends StyleProps {
-  readonly onClick: () => void;
+  onClick: () => void;
 }
 
 export default function CheckBox({

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -10,13 +10,13 @@ import { Backdrop, Container, Content, Header } from "./style";
 export type Position = "top" | "right" | "bottom" | "left";
 
 export interface DrawerProps {
-  readonly title?: React.ReactNode;
-  readonly isOpen?: boolean;
-  readonly showBackdrop?: boolean;
-  readonly position: Position;
-  readonly style?: React.CSSProperties;
-  readonly className?: string;
-  readonly onClose: () => void;
+  title?: React.ReactNode;
+  isOpen?: boolean;
+  showBackdrop?: boolean;
+  position: Position;
+  style?: React.CSSProperties;
+  className?: string;
+  onClose: () => void;
 }
 
 const variants = {

--- a/src/components/Layout/Menu.tsx
+++ b/src/components/Layout/Menu.tsx
@@ -3,15 +3,15 @@ import { Link } from "react-router-dom";
 import { Container } from "./Menu.style";
 
 export interface IMenu {
-  readonly id: string;
-  readonly title: string;
-  readonly to: string;
-  readonly icon: React.ReactNode;
+  id: string;
+  title: string;
+  to: string;
+  icon: React.ReactNode;
 }
 
 interface MenuProps {
-  readonly menu: IMenu;
-  readonly onClick: (id: string, e: React.MouseEvent) => void;
+  menu: IMenu;
+  onClick: (id: string, e: React.MouseEvent) => void;
 }
 
 export default function Menu({ menu, onClick }: MenuProps) {

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -8,11 +8,11 @@ import Menus from "./Menus";
 import { Profile, UserName, NeedLogin } from "./Sidebar.style";
 
 interface SidebarProps {
-  readonly isVisible: boolean;
-  readonly userName?: string;
-  readonly userImage?: string;
-  readonly onClose: () => void;
-  readonly onClickProfile: (e: React.MouseEvent) => void;
+  isVisible: boolean;
+  userName?: string;
+  userImage?: string;
+  onClose: () => void;
+  onClickProfile: (e: React.MouseEvent) => void;
 }
 
 export default function Sidebar({

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -11,10 +11,10 @@ import { Container } from "./style";
 export type Size = "sm" | "md" | "lg" | "xl";
 
 export interface ModalProps {
-  readonly isOpen?: boolean;
-  readonly size?: Size;
-  readonly showBackdrop?: boolean;
-  readonly onClose: () => void;
+  isOpen?: boolean;
+  size?: Size;
+  showBackdrop?: boolean;
+  onClose: () => void;
 }
 
 export default function Modal({

--- a/src/components/ModalActions/index.tsx
+++ b/src/components/ModalActions/index.tsx
@@ -5,7 +5,7 @@ import { Container } from "./style";
 type Direction = "row" | "col";
 
 export interface ModalActionsProps {
-  readonly direction?: Direction; // 정렬 방향
+  direction?: Direction; // 정렬 방향
 }
 
 export default function ModalActions({

--- a/src/components/Progress/index.tsx
+++ b/src/components/Progress/index.tsx
@@ -5,12 +5,12 @@ import { theme } from "@/styles/theme";
 import { Container } from "./style";
 
 export interface ProgressProps extends ComponentProps<"div"> {
-  readonly max?: number;
-  readonly min?: number;
-  readonly value?: number;
-  readonly color?: keyof typeof theme.colors;
-  readonly height?: number;
-  readonly isRounded?: boolean;
+  max?: number;
+  min?: number;
+  value?: number;
+  color?: keyof typeof theme.colors;
+  height?: number;
+  isRounded?: boolean;
 }
 
 export default function Progress({

--- a/src/components/Rating/index.tsx
+++ b/src/components/Rating/index.tsx
@@ -13,10 +13,10 @@ export type Size = "lg" | "md" | "sm";
 export type Color = "primary" | "secondary";
 
 export interface RatingProps extends ComponentProps<"div"> {
-  readonly size?: Size;
-  readonly color?: Color;
-  readonly readonly?: boolean;
-  readonly value?: number;
+  size?: Size;
+  color?: Color;
+  readonly?: boolean;
+  value?: number;
 }
 
 export default function Rating({

--- a/src/components/ResponsiveContainer/index.tsx
+++ b/src/components/ResponsiveContainer/index.tsx
@@ -3,7 +3,7 @@ import { StrictPropsWithChildren } from "@/types";
 import { Container } from "./style";
 
 interface ContainerProps {
-  readonly htmlType?: React.ElementType;
+  htmlType?: React.ElementType;
 }
 
 export default function ResponsiveContainer({

--- a/src/components/Stat/index.tsx
+++ b/src/components/Stat/index.tsx
@@ -11,18 +11,18 @@ import {
 } from "./style";
 
 interface StatItemProps {
-  readonly title?: string;
-  readonly data?: string;
-  readonly text?: string;
+  title?: string;
+  data?: string;
+  text?: string;
 }
 
 export interface StatStyleProps {
-  readonly primary?: boolean;
+  primary?: boolean;
 }
 
 interface StatProps extends StatStyleProps, ComponentProps<"div"> {
-  readonly items: StatItemProps[];
-  readonly className?: string;
+  items: StatItemProps[];
+  className?: string;
 }
 
 export default function Stat({ items, primary = false, ...props }: StatProps) {

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -4,19 +4,19 @@ import { useNavigate } from "react-router-dom";
 import { TabTitle, TabTitles } from "./style";
 
 export interface StyleProps {
-  readonly active?: boolean;
+  active?: boolean;
 }
 
 interface ItemProps {
-  readonly id: number;
-  readonly title?: string;
-  readonly children?: string;
-  readonly url?: string;
+  id: number;
+  title?: string;
+  children?: string;
+  url?: string;
 }
 
 interface TabsProps {
-  readonly defaultActiveId?: number;
-  readonly items: ItemProps[];
+  defaultActiveId?: number;
+  items: ItemProps[];
 }
 
 export default function Tabs({ defaultActiveId = 1, items }: TabsProps) {

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -3,13 +3,13 @@ import { ComponentProps } from "react";
 import { Message, TextareaBox, TextareaContainer } from "./style";
 
 export interface TextareaProps extends ComponentProps<"textarea"> {
-  readonly warn?: boolean;
-  readonly message?: string;
-  readonly className?: string;
+  warn?: boolean;
+  message?: string;
+  className?: string;
 }
 
 export interface TextareaBoxProps extends ComponentProps<"textarea"> {
-  readonly warn?: boolean;
+  warn?: boolean;
 }
 
 export default function Textarea({

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -3,15 +3,15 @@ import { ComponentProps } from "react";
 import { Message, TextInputBox, TextInputContainer } from "./style";
 
 export interface TextInputProps extends ComponentProps<"input"> {
-  readonly warn?: boolean;
-  readonly message?: string;
-  readonly className?: string;
-  readonly icon?: React.ReactNode;
+  warn?: boolean;
+  message?: string;
+  className?: string;
+  icon?: React.ReactNode;
 }
 
 export interface TextInputBoxProps extends ComponentProps<"input"> {
-  readonly warn?: boolean;
-  readonly hasIcon?: boolean;
+  warn?: boolean;
+  hasIcon?: boolean;
 }
 
 export default function TextInput({

--- a/src/features/admin/components/Layout/Menu.tsx
+++ b/src/features/admin/components/Layout/Menu.tsx
@@ -1,17 +1,17 @@
 import { NavLink } from "@mantine/core";
 
 export interface IMenu {
-  readonly id: string;
-  readonly label: React.ReactNode;
-  readonly icon?: React.ReactNode;
-  readonly to: string;
-  readonly initialOpened?: boolean; // 자식 아이템 목록 열림 여부
-  readonly children?: IMenu[];
+  id: string;
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+  to: string;
+  initialOpened?: boolean; // 자식 아이템 목록 열림 여부
+  children?: IMenu[];
 }
 
 interface MenuProps {
-  readonly menu: IMenu;
-  readonly onClick: (e: React.MouseEvent, to: string) => void;
+  menu: IMenu;
+  onClick: (e: React.MouseEvent, to: string) => void;
 }
 
 export default function Menu({ menu, onClick }: MenuProps) {

--- a/src/features/animations/components/AnimationRanking.tsx
+++ b/src/features/animations/components/AnimationRanking.tsx
@@ -16,17 +16,17 @@ import {
 
 // 임시 정의
 export interface IRanking {
-  readonly id: string;
-  readonly title: string;
-  readonly image: string;
-  readonly genre: string;
-  readonly rank: number;
-  readonly rating: number;
+  id: string;
+  title: string;
+  image: string;
+  genre: string;
+  rank: number;
+  rating: number;
 }
 
 interface AnimationRankingProps {
-  readonly title: string;
-  readonly contents: IRanking[];
+  title: string;
+  contents: IRanking[];
 }
 
 export default function AnimationRanking({

--- a/src/features/common/routes/Search.tsx
+++ b/src/features/common/routes/Search.tsx
@@ -121,10 +121,10 @@ const Container = styled.main`
 `;
 
 interface SearchbarProps extends ComponentProps<"div"> {
-  readonly value: string;
-  readonly onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  readonly onSearch: (e: React.FormEvent<HTMLFormElement>) => void;
-  readonly onCancel: () => void;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSearch: (e: React.FormEvent<HTMLFormElement>) => void;
+  onCancel: () => void;
 }
 
 function Searchbar({

--- a/src/features/reviews/components/ReviewLikeButton.tsx
+++ b/src/features/reviews/components/ReviewLikeButton.tsx
@@ -3,9 +3,9 @@ import { Heart } from "iconoir-react";
 import { Container } from "./ReviewLikeButton.style";
 
 export interface ReviewLikeButtonProps {
-  readonly isLike: boolean;
-  readonly count: number;
-  readonly onClick: () => void;
+  isLike: boolean;
+  count: number;
+  onClick: () => void;
 }
 
 export default function ReviewLikeButton({

--- a/src/features/reviews/components/ReviewSimpleCard.tsx
+++ b/src/features/reviews/components/ReviewSimpleCard.tsx
@@ -26,10 +26,10 @@ ReviewSimpleCard.Actions = Actions;
 
 // =================================== Header ===================================
 interface HeaderProps {
-  readonly rating: number;
-  readonly userId: string;
-  readonly userName: string;
-  readonly userImage?: string;
+  rating: number;
+  userId: string;
+  userName: string;
+  userImage?: string;
 }
 function Header({ rating, userId, userName, userImage }: HeaderProps) {
   return (
@@ -41,10 +41,10 @@ function Header({ rating, userId, userName, userImage }: HeaderProps) {
 }
 
 interface UserProps {
-  readonly id: string;
-  readonly name: string;
-  readonly image?: string;
-  readonly onClick?: () => void;
+  id: string;
+  name: string;
+  image?: string;
+  onClick?: () => void;
 }
 function User({ id, name, image }: UserProps) {
   return (


### PR DESCRIPTION
## 📝 개요

컴포넌트내에서 `prop.foo = 1;` 이런 형식이 아닌 이상 readonly 키워드가 의미가 없음.
즉, ` ({ foo } : Props) { foo = 1 ;}` 이 코드는 readonly를 써도 타입스크립트 컴파일러가 잡아내지 못함.
따라서 코드 가독성 향상을 위해 모든 prop interface의 readonly 키워드 제거

## 🚀 변경사항

prop interface들의 readonly 키워드 제거

## 🔗 관련 이슈

#98

## ➕ 기타



