### PR TITLE
feat: context 로그인 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { IconoirProvider } from "iconoir-react";
 import { HelmetProvider } from "react-helmet-async";
 import { RouterProvider } from "react-router-dom";
 
+import { AuthProvider } from "./contexts";
 import router from "./routes";
 import { theme } from "./styles/theme";
 
@@ -22,7 +23,9 @@ export default function App() {
               }
             `}
           />
-          <RouterProvider router={router} />
+          <AuthProvider>
+            <RouterProvider router={router} />
+          </AuthProvider>
         </IconoirProvider>
       </ThemeProvider>
     </HelmetProvider>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,54 @@
+import {
+  Dispatch,
+  SetStateAction,
+  createContext,
+  useState,
+  useMemo,
+} from "react";
+
+export interface UserProps {
+  name: string;
+  memberId: number;
+  imageUrl: null | string;
+  point: number;
+  role: string;
+  createdAt: string;
+  updateAt: string;
+}
+
+interface ContextProps {
+  user: UserProps;
+  loggedIn: boolean;
+  setUser: Dispatch<SetStateAction<UserProps>>;
+  setLoggedIn: Dispatch<SetStateAction<boolean>>;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const defaultUser = {
+  name: "",
+  memberId: 0,
+  imageUrl: "",
+  point: 0,
+  role: "",
+  createdAt: "",
+  updateAt: "",
+};
+
+export const AuthContext = createContext<ContextProps>({
+  setLoggedIn: () => {},
+  setUser: () => {},
+  user: defaultUser,
+  loggedIn: false,
+});
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<UserProps>(defaultUser);
+  const [loggedIn, setLoggedIn] = useState<boolean>(false);
+
+  const value = useMemo(
+    () => ({ setLoggedIn, setUser, loggedIn, user }),
+    [setLoggedIn, setUser, loggedIn, user],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from "./AuthContext";

--- a/src/features/auth/routes/Callback.tsx
+++ b/src/features/auth/routes/Callback.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { AuthContext, UserProps } from "@/contexts";
+import { request } from "@/lib/fetch";
+
+export default function Callback() {
+  const { setUser, setLoggedIn, loggedIn } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const getUser = async () => {
+    await request
+      .get<UserProps>("/auth/status")
+      .then((res) => {
+        setUser(res);
+        setLoggedIn(true);
+        navigate("/");
+      })
+      .catch((err) => {
+        alert(err);
+        navigate("login");
+      });
+  };
+
+  useEffect(() => {
+    if (loggedIn) navigate("/");
+    getUser();
+  }, []);
+
+  return <></>;
+}

--- a/src/features/auth/routes/Login.tsx
+++ b/src/features/auth/routes/Login.tsx
@@ -6,11 +6,17 @@ import Button from "@/components/Button";
 import Head from "@/components/Head";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 
+const BASE_URL = import.meta.env.VITE_BASE_URL;
+
 export default function Login() {
   const navigate = useNavigate();
 
   const handleClickBack = () => {
     navigate(-1);
+  };
+
+  const handleLogin = (site: string) => {
+    window.location.href = `${BASE_URL}auth/${site}/login`;
   };
 
   return (
@@ -40,18 +46,18 @@ export default function Login() {
           </Title>
           <SoicalGroup>
             <li>
-              <Button name="1" isBlock>
-                TODO로 로그인
+              <Button name="1" onClick={() => handleLogin("google")} isBlock>
+                구글 로그인
               </Button>
             </li>
             <li>
-              <Button name="1" isBlock>
-                TODO로 로그인
+              <Button name="1" onClick={() => handleLogin("naver")} isBlock>
+                네이버 로그인
               </Button>
             </li>
             <li>
-              <Button name="1" isBlock>
-                TODO로 로그인
+              <Button name="1" onClick={() => handleLogin("kakao")} isBlock>
+                카카오 로그인
               </Button>
             </li>
           </SoicalGroup>

--- a/src/hooks/useAuthFetch.tsx
+++ b/src/hooks/useAuthFetch.tsx
@@ -1,0 +1,44 @@
+import { useContext } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { AuthContext, defaultUser } from "@/contexts";
+
+const BASE_URL = import.meta.env.VITE_BASE_URL;
+
+export default function useAuthFetch() {
+  const navigate = useNavigate();
+  const { setLoggedIn, setUser } = useContext(AuthContext);
+
+  const authFetch = async (
+    url: string,
+    method: string = "GET",
+    infos: object = {},
+  ) => {
+    let data = {};
+
+    if (method === "GET" || method === "DELETE") {
+      data = {
+        method: method,
+        credentials: "include",
+      };
+    } else {
+      data = {
+        method: method,
+        credentials: "include",
+        ...infos,
+      };
+    }
+
+    const response = await fetch(BASE_URL + url, data);
+
+    if (response.status === 401) {
+      setLoggedIn(false);
+      setUser(defaultUser);
+      navigate("/login");
+    }
+
+    return response;
+  };
+
+  return authFetch;
+}

--- a/src/routes/publicRoutes.tsx
+++ b/src/routes/publicRoutes.tsx
@@ -2,6 +2,7 @@ import { lazy } from "react";
 import { RouteObject } from "react-router-dom";
 
 import Layout from "@/components/Layout";
+import Callback from "@/features/auth/routes/Callback";
 import Login from "@/features/auth/routes/Login";
 import Home from "@/features/common/routes/Home";
 
@@ -19,6 +20,10 @@ export const publicRoutes: RouteObject[] = [
   {
     path: "/login",
     element: <Login />,
+  },
+  {
+    path: "/auth/callback",
+    element: <Callback />,
   },
   {
     path: "/",


### PR DESCRIPTION
## 📝 개요

context를 사용해서 로그인 기능을 구현했습니다.
useAuthFetch를 통해 인증이 필요한 api를 사용하시면 됩니다.

### useFetchAuth

get, delete 는 3번째 인자 없이 사용하시면 됩니다.
post, put, patch는 3번째 인자에 header와 body를 object 형식으로 넣으시면 됩니다.

![code](https://github.com/oduck-team/oduck-client/assets/14821702/bd0f7b0b-0e2d-4c58-a245-362dfac8f9b8)

![useContext](https://github.com/oduck-team/oduck-client/assets/14821702/05cf531d-17a3-4775-bc3d-83bc8eea0dd2)

### .env.development 추가가 필요합니다.

VITE_BASE_URL=http://localhost:8000/api/v20230821/

## 🚀 변경사항

- AuthContext가 추가 되었습니다.
- Callback view가 추가 되었습니다.
- useAuthFetch 훅이 추가 되었습니다.

## 🔗 관련 이슈

#56 

## ➕ 기타

### 로그인 로직

1. /login 페이지에서 로그인 합니다.
2. 서버에 social url로 연결됩니다.
3. 로그인 성공하면 auth/callback view로 이동합니다.
4. auth/callback은 비어 있는 view 이며 세션 키가 유효하다면 로그인 상태를 true로 만들고 user 정보를 저장하고 홈으로 이동시킵니다. (실패할경우 로그인 뷰으로 이동)

### useAuthFetch 로직

1. 처음에 로그인 하면 AuthContext에서 loggedIn이 ture가 되고 user 변수에 사용자 정보가 담깁니다.
6. 서버와 api 통신 하는데 만약 session key가 만료되어서 401을 응답 받으면 user변수를 초기화 하고 loggedIn 변수도 false로 바뀝니다.

