### PR TITLE
feat: BottomSheet 핸들바

### DIFF
--- a/src/components/Backdrop/style.ts
+++ b/src/components/Backdrop/style.ts
@@ -7,8 +7,6 @@ import { BackdropProps } from ".";
 export const Container = styled(motion.div)<BackdropProps>`
   position: fixed;
   display: flex;
-  align-items: center;
-  justify-content: center;
   inset: 0;
 
   ${({ isVisible }) => css`

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -33,7 +33,7 @@ export default function BottomSheet({
   onClose,
   children,
 }: StrictPropsWithChildren<BottomSheetProps>) {
-  useScrollLock(isOpen);
+  // useScrollLock(isOpen);
   const controls = useAnimation();
   const dragControls = useDragControls(); // drag 이벤트 일어나는 시점을 지정
   const contentContainerRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -1,57 +1,113 @@
-import { AnimatePresence } from "framer-motion";
+import { AnimatePresence, useAnimation, useDragControls } from "framer-motion";
+import { useEffect, useRef } from "react";
 
 import { useScrollLock } from "@/hooks/useScrollLock";
 import { StrictPropsWithChildren } from "@/types";
 
 import Portal from "../Portal";
 
-import { Backdrop, Container, Header, Content, Footer } from "./style";
+import {
+  Backdrop,
+  Container,
+  Handlebar,
+  ContentContainer,
+  Content,
+  Footer,
+} from "./style";
 
-export interface BottomSheetProps {
-  isOpen?: boolean;
+const HANDLEBAR_HEIGHT = 30;
+const FOOTER_HEGIHT = 80;
+
+BottomSheet.Content = Content;
+BottomSheet.Footer = Footer;
+
+interface BottomSheetProps {
   showBackdrop?: boolean;
-  header?: {
-    left?: React.ReactNode;
-    title?: string;
-    right?: React.ReactNode;
-  };
-  footer?: React.ReactNode;
+  isOpen?: boolean;
   onClose: () => void;
 }
 
 export default function BottomSheet({
   isOpen = false,
   showBackdrop = true,
-  header,
-  footer,
   onClose,
   children,
 }: StrictPropsWithChildren<BottomSheetProps>) {
   useScrollLock(isOpen);
+  const controls = useAnimation();
+  const dragControls = useDragControls(); // drag 이벤트 일어나는 시점을 지정
+  const contentContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen && contentContainerRef.current) {
+      const contentHeight = contentContainerRef.current.offsetHeight;
+
+      // BottomSheet 컴포넌트가 화면에 보여질 때 실제 높이입니다.
+      // Content 높이, Handlebar 높이, Footer 높이를 합한 값과
+      // 화면 높이에서 50을 뺀 값 중 작은 것을 선택하여 화면 최상단을 넘어가지 않게합니다.
+      const visibleHeight = Math.min(
+        contentHeight + HANDLEBAR_HEIGHT + FOOTER_HEGIHT,
+        window.innerHeight - 50,
+      );
+
+      const topValue = `calc(100dvh - ${visibleHeight}px)`;
+      controls.start({ top: topValue, bottom: 0 });
+    } else {
+      controls.start("hidden");
+    }
+  }, [isOpen, controls]);
+
+  // 모바일 pull to refresh를 막아줍니다.
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+  }, [isOpen]);
 
   return (
     <AnimatePresence>
       {isOpen && (
         <Portal elementId="modal-root">
-          <Backdrop isVisible={showBackdrop} onClick={onClose}>
+          <Backdrop isVisible={showBackdrop} onClick={() => {}}>
             <Container
               aria-modal={isOpen}
               role="dialog"
-              initial="hidden"
-              animate="visible"
-              exit="exit"
-              variants={variants}
+              initial={{ top: "100dvh" }}
+              animate={controls}
+              exit={{ top: "100dvh" }}
+              drag="y"
+              dragConstraints={{ top: 0, bottom: 0 }}
+              dragControls={dragControls}
+              dragListener={false}
+              dragElastic={0.2} // 외부 제약을 허용하는 조건(제약 범위를 벗어날수록 돌아가려는 움직임의 정도)
+              onDragEnd={(_, info) => {
+                const DRAG_SPEED_THRESHOLD = 1000; // 드래그 속도 임계값
+                const DRAG_DISTANCE_THRESHOLD = 50; // 드래그 거리 임계값. 값이 크면 android에서 반응을 못함
+
+                const shouldClose =
+                  info.velocity.y > DRAG_SPEED_THRESHOLD ||
+                  (info.velocity.y >= 0 &&
+                    info.point.y > DRAG_DISTANCE_THRESHOLD);
+
+                if (shouldClose) {
+                  controls.start("hidden");
+                  onClose();
+                } else {
+                  controls.start("visible");
+                }
+              }}
               onClick={(e) => e.stopPropagation()}
             >
-              {header && (
-                <Header>
-                  <div className="left">{header.left}</div>
-                  <div className="center">{header.title}</div>
-                  <div className="right">{header.right}</div>
-                </Header>
-              )}
-              <Content>{children}</Content>
-              {footer && <Footer>{footer}</Footer>}
+              <Handlebar
+                aria-label="핸들바"
+                tabIndex={0}
+                onPointerDown={(e) => dragControls.start(e)}
+              />
+              <ContentContainer ref={contentContainerRef}>
+                {children}
+              </ContentContainer>
             </Container>
           </Backdrop>
         </Portal>
@@ -59,30 +115,3 @@ export default function BottomSheet({
     </AnimatePresence>
   );
 }
-
-const variants = {
-  hidden: {
-    y: "100%",
-    opacity: 0,
-    transition: {
-      duration: 0.2,
-      ease: "easeInOut",
-    },
-  },
-  visible: {
-    y: "0%",
-    opacity: 1,
-    transition: {
-      duration: 0.2,
-      ease: "easeInOut",
-    },
-  },
-  exit: {
-    y: "100%",
-    opacity: 0,
-    transition: {
-      duration: 0.2,
-      ease: "easeInOut",
-    },
-  },
-};

--- a/src/components/BottomSheet/style.ts
+++ b/src/components/BottomSheet/style.ts
@@ -4,59 +4,80 @@ import { motion } from "framer-motion";
 import BaseBackdrop from "../Backdrop";
 
 export const Backdrop = styled(BaseBackdrop)`
+  justify-content: center;
   z-index: ${({ theme }) => theme.zIndex.bottomSheet};
 `;
 
 export const Container = styled(motion.div)`
-  position: fixed;
+  position: relative;
+  bottom: 0;
   display: flex;
   flex-direction: column;
-  padding: 32px 24px;
-  max-height: 80%;
+  height: 100lvh;
   width: 100%;
   max-width: 600px;
-  bottom: 0;
-  background-color: ${({ theme }) => theme.colors.neutral["05"]};
-  border-radius: 30px 30px 0px 0px;
-  box-shadow: 0px -5px 16px 0px rgba(0, 0, 0, 0.09);
+  background-color: #ffffff;
+  border-radius: 20px 20px 0px 0px;
   overflow: hidden;
 `;
 
-export const Header = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  padding-bottom: 1rem;
+export const Handlebar = styled.div`
+  min-height: 30px;
+  cursor: grab;
 
-  // 각 영역의 내용을 중앙에 배치
-  .left,
-  .center,
-  .right {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  // 왼쪽 영역의 내용을 왼쪽에 배치
-  .left {
-    justify-content: flex-start;
-  }
-
-  // 오른쪽 영역의 내용을 오른쪽에 배치
-  .right {
-    justify-content: flex-end;
+  &::before {
+    position: absolute;
+    top: 14px;
+    left: 50%;
+    transform: translateX(-50%);
+    content: "";
+    display: block;
+    height: 4px;
+    width: 40px;
+    border-radius: 5px;
+    background-color: ${({ theme }) => theme.colors.neutral["30"]};
+    box-shadow: inset 0px 0.5px 0.1px rgba(0, 0, 0, 0.06);
   }
 `;
 
-export const Content = styled.div`
+export const ContentContainer = styled.div`
+  height: fit-content;
   overflow-y: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;
-
   &::-webkit-scrollbar {
     display: none;
   }
 `;
 
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 24px;
+  padding-bottom: 250px; // mobile
+
+  ${({ theme }) => theme.mq("sm")} {
+    padding-bottom: 50px;
+  }
+`;
+
 export const Footer = styled.div`
-  margin-top: 1rem;
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 24px;
+  padding-top: 14px;
+  gap: 40px;
+  min-height: fit-content;
+  width: 100%;
+  max-width: 600px;
+  background-color: #ffffff;
+  border-top: solid 1px ${({ theme }) => theme.colors.neutral["10"]};
+  z-index: 1000;
+
+  button {
+    flex-shrink: 0;
+  }
 `;

--- a/src/components/BottomSheet/style.ts
+++ b/src/components/BottomSheet/style.ts
@@ -41,7 +41,8 @@ export const Handlebar = styled.div`
 `;
 
 export const ContentContainer = styled.div`
-  height: fit-content;
+  height: 100%;
+  max-height: 400px;
   overflow-y: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;
@@ -54,11 +55,7 @@ export const Content = styled.div`
   display: flex;
   flex-direction: column;
   padding: 0 24px;
-  padding-bottom: 250px; // mobile
-
-  ${({ theme }) => theme.mq("sm")} {
-    padding-bottom: 50px;
-  }
+  padding-bottom: 50px;
 `;
 
 export const Footer = styled.div`

--- a/src/features/animations/routes/List.tsx
+++ b/src/features/animations/routes/List.tsx
@@ -128,25 +128,8 @@ export default function AnimationList() {
       <BottomSheet
         isOpen={bottomSheetOpen}
         onClose={() => setBottomSheetOpen(false)}
-        footer={
-          <Footer>
-            <ResetButton
-              styleType="text"
-              size="sm"
-              name="초기화"
-              onClick={resetFilter}
-              color="neutral"
-            >
-              필터 초기화
-            </ResetButton>
-            <OkButton name="적용 완료" size="lg" onClick={handlerOkClick}>
-              적용 완료
-            </OkButton>
-          </Footer>
-        }
       >
-        <FilterContainer>
-          <Cancel width={24} height={24} onClick={handlerCloseClick} />
+        <BottomSheet.Content>
           {filtered.length > 0 && (
             <ChipsContiner style={{ marginBottom: "24px" }}>
               <h3 style={{ marginTop: "0" }}>선택된 필터</h3>
@@ -241,7 +224,21 @@ export default function AnimationList() {
               ))}
             </Chips>
           </ChipsContiner>
-        </FilterContainer>
+        </BottomSheet.Content>
+        <BottomSheet.Footer>
+          <ResetButton
+            styleType="text"
+            size="sm"
+            name="초기화"
+            onClick={resetFilter}
+            color="neutral"
+          >
+            필터 초기화
+          </ResetButton>
+          <OkButton name="적용 완료" size="lg" onClick={handlerOkClick}>
+            적용 완료
+          </OkButton>
+        </BottomSheet.Footer>
       </BottomSheet>
     </Container>
   );
@@ -256,6 +253,7 @@ const Container = styled.div`
   flex-direction: column;
   padding-bottom: 66px;
 `;
+
 const Header = styled.div`
   background-color: white;
   width: 100%;
@@ -281,16 +279,6 @@ const Content = styled.div`
   padding: 166px 16px 92px;
 `;
 
-const FilterContainer = styled.div`
-  position: relative;
-  & > svg {
-    position: fixed;
-    top: 32px;
-    right: 24px;
-    z-index: ${({ theme }) => theme.zIndex.bottomSheet + 1};
-  }
-`;
-
 const ChipsContiner = styled.div`
   position: relative;
   h3 {
@@ -305,17 +293,6 @@ const Chips = styled.div`
   display: flex;
   gap: 8px 4px;
   flex-wrap: wrap;
-`;
-
-const Footer = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 40px;
-  button {
-    flex-shrink: 0;
-  }
 `;
 
 const OkButton = styled(Button)`

--- a/src/hooks/useScrollLock.ts
+++ b/src/hooks/useScrollLock.ts
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 
-export function useScrollLock(isFix: boolean) {
+export function useScrollLock(isLock: boolean) {
   useEffect(() => {
-    if (isFix) {
+    if (isLock) {
       document.body.style.cssText = `
         position: fixed; 
         top: -${window.scrollY}px;
@@ -15,5 +15,5 @@ export function useScrollLock(isFix: boolean) {
         window.scrollTo(0, parseInt(scrollY || "0") * -1);
       };
     }
-  }, [isFix]);
+  }, [isLock]);
 }


### PR DESCRIPTION
## 📝 개요
BottomSheet 핸들바 구현

https://github.com/oduck-team/oduck-client/assets/105474635/1eefdddf-f2de-41ca-844e-c34f4b5e8cf5






## 🚀 변경사항

Bottom Sheet 구조 변경
이전
```html
<BottomSheet footer={...푸터}>
  컨텐츠
</BottomSheet>  
```
이후
```html
<BottomSheet>
  <BottomSheet.Content >...
  <BottomSheet.Footer> ...
</BottomSheet>  
```
## 🔗 관련 이슈

(이 PR과 관련된 이슈 번호를 제공해주세요. <ex> #123)

## ➕ 기타

원래는 bottom sheet 최대 높이를
`컨텐츠 높이` || `컨텐츠가 상단을 초과할경우 상단 - 50px`으로 하려했는데, (구현은 함)
ios safari에서 주소창이 동적으로 변화해 하단 패딩이 가려져서 컨텐츠의 최대 높이를 400px로 제한했습니다
<img width="500" alt="스크린샷 2023-09-08 오후 2 05 45" src="https://github.com/oduck-team/oduck-client/assets/105474635/5787ca1b-9f5b-4c3b-b671-73cbf5812699">
위의 172.30.. 주소창이 나타날경우 `100화 이하` `100화 이상` 하단 패딩이 가려져서 `적용 완료` 푸터 영역에 가려지네요. css `env(safe-area-inset-bottom)`걸로도 해결이 안되서 임시방편입니다

참고 https://stackoverflow.com/questions/68094609/ios-15-safari-floating-address-bar
