### PR TITLE
fix: 애니 상세페이지 우측 여백

### DIFF
--- a/src/features/animations/routes/Detail/Hero.style.ts
+++ b/src/features/animations/routes/Detail/Hero.style.ts
@@ -58,7 +58,7 @@ export const Info = styled.div`
   flex-direction: column;
   position: absolute;
   bottom: 56px;
-  margin: 0 16px;
+  padding: 0 16px;
   ${({ theme }) => theme.mq("md")} {
     padding: 0 40px;
   }


### PR DESCRIPTION
## 📝 개요
애니 상세페이지 우측 여백이 발생하여 수정하였습니다 (이슈 참고)

## 🚀 변경사항

margin -> padding

## 🔗 관련 이슈

#111

## ➕ 기타



