### PR TITLE
refactor: useFetch 구현 내용 수정

### DIFF
--- a/src/features/animations/hooks/useAnimation.ts
+++ b/src/features/animations/hooks/useAnimation.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useParams } from "react-router-dom";
 
 import useFetch from "@/hooks/useFetch";
@@ -6,15 +7,15 @@ import { IAnimation } from "../types";
 
 export function useAnimation() {
   const { id } = useParams();
-  const { data, error, isLoading } = useFetch<IAnimation>(`/animation/${id}`);
+  const { data, error, isLoading, fetcher } = useFetch<IAnimation>();
 
-  if (isNaN(Number(id))) {
-    return {
-      animation: undefined,
-      isAnimationLoading: isLoading,
-      animationError: new Error("Not Found"),
-    };
-  }
+  useEffect(() => {
+    if (isNaN(Number(id))) {
+      return;
+    }
+
+    fetcher(`/animation/${id}`);
+  }, [id, fetcher]);
 
   return {
     animation: data,

--- a/src/hooks/useFetch.test.ts
+++ b/src/hooks/useFetch.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { ApiError } from "@/lib/error";
+
+import useFetch from "./useFetch";
+
+describe("hooks/useFetch", () => {
+  const mockedFetch = vi.fn();
+
+  beforeEach(() => {
+    global.fetch = mockedFetch;
+  });
+
+  afterEach(() => {
+    // mock.mockClear();
+  });
+
+  it("fetcher가 호출되면 isLoading이여야 한다", async () => {
+    const { result } = renderHook(() => useFetch<string>());
+
+    act(() => {
+      result.current.fetcher("/test");
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("응답이 성공적으로 오면 isFetched이여야 한다", async () => {
+    mockedFetch.mockResolvedValueOnce({
+      status: 200,
+      json: () => Promise.resolve({ data: "test" }),
+    });
+    const { result } = renderHook(() => useFetch<string>());
+
+    await act(async () => {
+      await result.current.fetcher("/test");
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetched).toBe(true);
+  });
+
+  it("api 에러 발생시 isError여야하며 error값에 message를 포함한다", async () => {
+    mockedFetch.mockRejectedValueOnce(new ApiError("Bad Request"));
+    const { result } = renderHook(() => useFetch<string>());
+
+    await act(async () => {
+      await result.current.fetcher("/test");
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(true);
+    expect((result.current.error as ApiError).message).toEqual("Bad Request");
+    expect(result.current.error).toBeInstanceOf(ApiError);
+  });
+});


### PR DESCRIPTION
## 📝 개요

기존의 useFetch 구현 내부에서 useEffect로 데이터 받아오는 것에 위주로 되어있어서, 
useEffect를 벗긴후 fetcher 함수를 반환해 원하는 시점에 서버에 요청할 수 있게 수정했습니다
```ts
const { data, error, isLoading, fetcher } = useFetch<IAnimation>();

useEffect(() => {
  fetcher(`/animation/${id}`);
}, [id, fetcher]);

// 또는 

const { data, error, isLoading, isFetched, isError, fetcher } = useFetch();

const handleSignup = (name: string) => {
  fetcher("/members/signup", {
    method: "POST",
    body: JSON.stringify({ name }),
  });
};

```


## 🚀 변경사항
- useAnimation에 적용

## 🔗 관련 이슈

#119

## ➕ 기타

