### PR TITLE
feat. 랜딩 페이지 기능 일부 구현

### DIFF
--- a/src/features/auth/hooks/useSignUp.ts
+++ b/src/features/auth/hooks/useSignUp.ts
@@ -1,0 +1,15 @@
+import useFetch from "@/hooks/useFetch";
+
+export default function useSignUp() {
+  const { error, fetcher } = useFetch();
+
+  const handleSignUp = async (name: string) => {
+    await fetcher("/members/signup", {
+      method: "POST",
+      body: JSON.stringify({ name }),
+    });
+    return { nameError: error };
+  };
+
+  return { handleSignUp };
+}

--- a/src/features/common/routes/Home/Discord.tsx
+++ b/src/features/common/routes/Home/Discord.tsx
@@ -1,0 +1,67 @@
+import styled from "@emotion/styled";
+
+export default function Discord() {
+  return (
+    <Container>
+      <div>
+        <span>오덕&nbsp;</span>
+        <span>Discord</span>
+      </div>
+      <p>오덕 디스코드에 참여해 보세요!</p>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="29"
+        height="22"
+        viewBox="0 0 29 22"
+        fill="none"
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M24.6175 1.88492C24.6175 1.88492 22.1878 0.24234 18.3431 0L17.8089 1.53485C17.8128 1.52399 16.1014 1.26639 15.9905 1.25543C15.0223 1.15961 13.9886 1.17038 13.0184 1.24567C12.9046 1.25452 11.1898 1.53192 11.1907 1.53494L10.6566 9.15527e-05C6.81183 0.242432 4.38214 1.88501 4.38214 1.88501C-1.35858 10.825 0.19025 18.1763 0.19025 18.1763C2.11261 20.2228 7.63947 22 7.63947 22L9.10773 19.4149L6.75812 18.3379L7.10529 17.6378C9.12482 18.6562 11.4383 19.2146 13.6907 19.3363C15.7054 19.4451 17.765 19.1317 19.6873 18.5265C19.8001 18.4911 19.9124 18.4544 20.0242 18.4164C20.2874 18.3272 20.5486 18.2311 20.8065 18.1277C20.9119 18.0853 21.8651 17.6085 21.8939 17.6378L22.241 18.3379L19.8914 19.4149L21.3602 22C21.3602 22 26.887 20.2228 28.8094 18.1763C28.8094 18.1763 30.3582 10.825 24.6175 1.88492ZM9.72199 14.864C11.1639 14.864 12.3323 13.5801 12.3323 11.9963C12.3323 10.4124 11.1639 9.12851 9.72199 9.12851C8.28058 9.12851 7.11212 10.4124 7.11212 11.9963C7.11212 13.5801 8.28058 14.864 9.72199 14.864ZM21.8875 11.9963C21.8875 13.5801 20.7191 14.864 19.2772 14.864C17.8358 14.864 16.6673 13.5801 16.6673 11.9963C16.6673 10.4124 17.8358 9.12851 19.2772 9.12851C20.7191 9.12851 21.8875 10.4124 21.8875 11.9963Z"
+          fill="white"
+        />
+      </svg>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  width: calc(100% - 32px);
+  height: 80px;
+  margin: 0 auto;
+  border-radius: 5px;
+  background-color: ${({ theme }) => theme.colors["primary"]["60"]};
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0 18px;
+
+  span {
+    ${({ theme }) => theme.typo["title-2-b"]};
+    font-family: "Gmarket Sans";
+    line-height: 120%;
+  }
+
+  span:first-of-type {
+    color: ${({ theme }) => theme.colors["neutral"]["05"]};
+  }
+
+  span:last-of-type {
+    color: ${({ theme }) => theme.colors["neutral"]["10"]};
+  }
+
+  & > p {
+    ${({ theme }) => theme.typo["body-3-r"]};
+    color: ${({ theme }) => theme.colors["neutral"]["20"]};
+  }
+
+  & > svg {
+    width: 29px;
+    height: 22px;
+    position: absolute;
+    top: 29px;
+    right: 30px;
+  }
+`;

--- a/src/features/common/routes/Home/NameModal.tsx
+++ b/src/features/common/routes/Home/NameModal.tsx
@@ -1,8 +1,11 @@
 import styled from "@emotion/styled";
+import { useState } from "react";
 
 import Button from "@/components/Button";
 import Modal from "@/components/Modal";
 import TextInput from "@/components/TextInput";
+import useSignUp from "@/features/auth/hooks/useSignUp";
+import useAuth from "@/hooks/useAuth";
 
 interface Props {
   isVisible: boolean;
@@ -10,10 +13,38 @@ interface Props {
 }
 
 export default function NameModal({ isVisible, onClose }: Props) {
-  const handlerSetName = () => {
-    // TODO 닉네임 패턴 검사
-    // TODO api request
-    onClose();
+  const { handleSignUp } = useSignUp();
+  const { fetchUser } = useAuth();
+  const [name, setName] = useState("");
+  const [error, setError] = useState(0);
+  const errorMessage = [
+    "",
+    "닉네임을 입력해 주세요.",
+    "닉네임은 2~10자로, 한글 또는 영어를 반드시 포함해야 합니다.",
+  ];
+
+  const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+  };
+
+  const handlerSetName = async () => {
+    // 닉네임 패턴 검사
+    const namePattern = /^(?=.*[a-zA-Z가-힣])[A-Za-z가-힣0-9]{2,10}$/;
+    setError(() => {
+      if (name === "") return 1;
+      else if (!namePattern.test(name)) return 2;
+      else return 0;
+    });
+    if (namePattern.test(name)) {
+      // api 요청
+      const { nameError } = await handleSignUp(name);
+      if (nameError) {
+        console.log("error", nameError);
+      } else {
+        fetchUser();
+        onClose();
+      }
+    }
   };
 
   return (
@@ -22,7 +53,14 @@ export default function NameModal({ isVisible, onClose }: Props) {
         <ModalContentText>
           환영합니다! <br /> 오덕에서 사용할 닉네임을 설정해 주세요.
         </ModalContentText>
-        <TextInput style={{ width: "100%" }} placeholder="닉네임" />
+        <TextInput
+          style={{ width: "100%" }}
+          placeholder="닉네임 (2~10자, 한글 또는 영어 필수)"
+          value={name}
+          onChange={onChangeName}
+          warn={Boolean(error)}
+          message={errorMessage[error]}
+        />
       </Modal.Content>
       <Modal.Actions>
         <Button

--- a/src/features/common/routes/Home/NameModal.tsx
+++ b/src/features/common/routes/Home/NameModal.tsx
@@ -1,0 +1,44 @@
+import styled from "@emotion/styled";
+
+import Button from "@/components/Button";
+import Modal from "@/components/Modal";
+import TextInput from "@/components/TextInput";
+
+interface Props {
+  isVisible: boolean;
+  onClose: () => void;
+}
+
+export default function NameModal({ isVisible, onClose }: Props) {
+  const handlerSetName = () => {
+    // TODO 닉네임 패턴 검사
+    // TODO api request
+    onClose();
+  };
+
+  return (
+    <Modal isVisible={isVisible} onClose={onClose}>
+      <Modal.Content>
+        <ModalContentText>
+          환영합니다! <br /> 오덕에서 사용할 닉네임을 설정해 주세요.
+        </ModalContentText>
+        <TextInput style={{ width: "100%" }} placeholder="닉네임" />
+      </Modal.Content>
+      <Modal.Actions>
+        <Button
+          style={{ margin: "6px 8px 0" }}
+          name="확인"
+          isBlock
+          onClick={handlerSetName}
+        >
+          확인
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+}
+
+const ModalContentText = styled.p`
+  ${({ theme }) => theme.typo["title-3-m"]};
+  margin-bottom: 8px;
+`;

--- a/src/features/common/routes/Home/RecentReview.tsx
+++ b/src/features/common/routes/Home/RecentReview.tsx
@@ -1,0 +1,70 @@
+import styled from "@emotion/styled";
+
+import Button from "@/components/Button";
+import ReviewCard from "@/features/reviews/components/ReviewCard";
+import ReviewLikeButton from "@/features/reviews/components/ReviewLikeButton";
+import ReviewMoreButton from "@/features/reviews/components/ReviewMoreButton";
+
+export default function RecentReview() {
+  return (
+    <Container>
+      <Header>
+        <h1>최근 한줄리뷰</h1>
+        <Button name="더보기" styleType="text" size="sm" color="neutral">
+          더보기
+        </Button>
+      </Header>
+      <StyleCardReview>
+        <ReviewCard.Animation
+          title="레벨 1이지만 유니크 스킬로 최강이 되었습니다"
+          image="https://url.kr/4gtucf"
+          rating={10}
+        />
+        <ReviewCard.Content>
+          너무너무 재밌게 안 봤습니다. 애니제목을 왜 이딴식으로 짓는지 이해가 안
+          가네요
+          하하하하하하하하하하하하하하하하하하하하핳아항항핳하아항하하하하아항하아항하아항항
+        </ReviewCard.Content>
+        <ReviewCard.Actions
+          style={{ display: "flex", justifyContent: "space-between" }}
+        >
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <time dateTime="2023-04-01" style={{ fontSize: "12px" }}>
+              2023.07.30
+            </time>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            <ReviewLikeButton isLike={false} count={0} onClick={() => {}} />
+            <ReviewMoreButton />
+          </div>
+        </ReviewCard.Actions>
+      </StyleCardReview>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-bottom: solid 1px ${({ theme }) => theme.colors["neutral"]["05"]};
+`;
+
+const Header = styled.div`
+  width: 100%;
+  padding: 0 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  & > h1 {
+    color: ${({ theme }) => theme.colors["neutral"]["100"]};
+    ${({ theme }) => theme.typo["title-2-m"]};
+  }
+`;
+
+const StyleCardReview = styled(ReviewCard)`
+  border-top: solid 2px ${({ theme }) => theme.colors["neutral"]["05"]};
+  border-bottom: solid 2px ${({ theme }) => theme.colors["neutral"]["05"]};
+`;

--- a/src/features/common/routes/Home/index.tsx
+++ b/src/features/common/routes/Home/index.tsx
@@ -158,13 +158,14 @@ export default function Home() {
 
   const { user, isLoggedIn } = useAuth();
   const navigate = useNavigate();
-  const [isnameModalVisible, setIsNameModalVisible] = useState(false);
+  const [isNameModalVisible, setIsNameModalVisible] = useState(false);
 
   const handlerReviewButtonClick = () => {
     if (isLoggedIn) navigate("/search");
     else navigate("/login");
   };
 
+  // 닉네임 설정을 하지 않은 상태라면 닉네임 설정 모달창 띄움
   useEffect(() => {
     if (isLoggedIn && user.name[14] === "4") {
       setIsNameModalVisible(true);
@@ -174,7 +175,7 @@ export default function Home() {
   return (
     <Container>
       <NameModal
-        isVisible={isnameModalVisible}
+        isVisible={isNameModalVisible}
         onClose={() => setIsNameModalVisible(false)}
       />
       <AnimationCarousel animations={CarouselAni} />

--- a/src/features/common/routes/Home/index.tsx
+++ b/src/features/common/routes/Home/index.tsx
@@ -1,4 +1,6 @@
 import styled from "@emotion/styled";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import Button from "@/components/Button";
 import AnimationCarousel, {
@@ -8,8 +10,10 @@ import AnimationRanking, {
   IRanking,
 } from "@/features/animations/components/AnimationRanking";
 import AnimationSlide from "@/features/animations/components/AnimationSlide";
+import useAuth from "@/hooks/useAuth";
 
 import Discord from "./Discord";
+import NameModal from "./NameModal";
 import RecentReview from "./RecentReview";
 
 export default function Home() {
@@ -152,8 +156,27 @@ export default function Home() {
     CardAni2,
   ];
 
+  const { user, isLoggedIn } = useAuth();
+  const navigate = useNavigate();
+  const [isnameModalVisible, setIsNameModalVisible] = useState(false);
+
+  const handlerReviewButtonClick = () => {
+    if (isLoggedIn) navigate("/search");
+    else navigate("/login");
+  };
+
+  useEffect(() => {
+    if (isLoggedIn && user.name[14] === "4") {
+      setIsNameModalVisible(true);
+    }
+  }, [user, isLoggedIn]);
+
   return (
     <Container>
+      <NameModal
+        isVisible={isnameModalVisible}
+        onClose={() => setIsNameModalVisible(false)}
+      />
       <AnimationCarousel animations={CarouselAni} />
       <AnimationRanking title="이번주 TOP10" contents={RankingAni} />
       <Discord />
@@ -163,7 +186,7 @@ export default function Home() {
       <AnimationSlide title="이불밖을 못 나오게 하는" animations={SlideAni} />
       <Bottom>
         <span>감명 깊게 본 애니를 다른 회원님들과 공유해보세요!</span>
-        <Button name="리뷰" size="lg">
+        <Button name="리뷰" size="lg" onClick={handlerReviewButtonClick}>
           한줄리뷰 남기러가기
         </Button>
       </Bottom>

--- a/src/features/common/routes/Home/index.tsx
+++ b/src/features/common/routes/Home/index.tsx
@@ -8,9 +8,9 @@ import AnimationRanking, {
   IRanking,
 } from "@/features/animations/components/AnimationRanking";
 import AnimationSlide from "@/features/animations/components/AnimationSlide";
-import ReviewCard from "@/features/reviews/components/ReviewCard";
-import ReviewLikeButton from "@/features/reviews/components/ReviewLikeButton";
-import ReviewMoreButton from "@/features/reviews/components/ReviewMoreButton";
+
+import Discord from "./Discord";
+import RecentReview from "./RecentReview";
 
 export default function Home() {
   const CarouselAni: Animation[] = [
@@ -156,61 +156,9 @@ export default function Home() {
     <Container>
       <AnimationCarousel animations={CarouselAni} />
       <AnimationRanking title="이번주 TOP10" contents={RankingAni} />
-      <DiscordContainer>
-        <div>
-          <span>오덕&nbsp;</span>
-          <span>Discord</span>
-        </div>
-        <p>오덕 디스코드에 참여해 보세요!</p>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="29"
-          height="22"
-          viewBox="0 0 29 22"
-          fill="none"
-        >
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            d="M24.6175 1.88492C24.6175 1.88492 22.1878 0.24234 18.3431 0L17.8089 1.53485C17.8128 1.52399 16.1014 1.26639 15.9905 1.25543C15.0223 1.15961 13.9886 1.17038 13.0184 1.24567C12.9046 1.25452 11.1898 1.53192 11.1907 1.53494L10.6566 9.15527e-05C6.81183 0.242432 4.38214 1.88501 4.38214 1.88501C-1.35858 10.825 0.19025 18.1763 0.19025 18.1763C2.11261 20.2228 7.63947 22 7.63947 22L9.10773 19.4149L6.75812 18.3379L7.10529 17.6378C9.12482 18.6562 11.4383 19.2146 13.6907 19.3363C15.7054 19.4451 17.765 19.1317 19.6873 18.5265C19.8001 18.4911 19.9124 18.4544 20.0242 18.4164C20.2874 18.3272 20.5486 18.2311 20.8065 18.1277C20.9119 18.0853 21.8651 17.6085 21.8939 17.6378L22.241 18.3379L19.8914 19.4149L21.3602 22C21.3602 22 26.887 20.2228 28.8094 18.1763C28.8094 18.1763 30.3582 10.825 24.6175 1.88492ZM9.72199 14.864C11.1639 14.864 12.3323 13.5801 12.3323 11.9963C12.3323 10.4124 11.1639 9.12851 9.72199 9.12851C8.28058 9.12851 7.11212 10.4124 7.11212 11.9963C7.11212 13.5801 8.28058 14.864 9.72199 14.864ZM21.8875 11.9963C21.8875 13.5801 20.7191 14.864 19.2772 14.864C17.8358 14.864 16.6673 13.5801 16.6673 11.9963C16.6673 10.4124 17.8358 9.12851 19.2772 9.12851C20.7191 9.12851 21.8875 10.4124 21.8875 11.9963Z"
-            fill="white"
-          />
-        </svg>
-      </DiscordContainer>
+      <Discord />
       <AnimationSlide title="2023년 3분기 신작" animations={SlideAni} />
-      <RecentReview>
-        <Header>
-          <h1>최근 한줄리뷰</h1>
-          <Button name="더보기" styleType="text" size="sm" color="neutral">
-            더보기
-          </Button>
-        </Header>
-        <StyleCardReview>
-          <ReviewCard.Animation
-            title="레벨 1이지만 유니크 스킬로 최강이 되었습니다"
-            image="https://url.kr/4gtucf"
-            rating={10}
-          />
-          <ReviewCard.Content>
-            너무너무 재밌게 안 봤습니다. 애니제목을 왜 이딴식으로 짓는지 이해가
-            안 가네요
-            하하하하하하하하하하하하하하하하하하하하핳아항항핳하아항하하하하아항하아항하아항항
-          </ReviewCard.Content>
-          <ReviewCard.Actions
-            style={{ display: "flex", justifyContent: "space-between" }}
-          >
-            <div style={{ display: "flex", alignItems: "center" }}>
-              <time dateTime="2023-04-01" style={{ fontSize: "12px" }}>
-                2023.07.30
-              </time>
-            </div>
-            <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-              <ReviewLikeButton isLike={false} count={0} onClick={() => {}} />
-              <ReviewMoreButton />
-            </div>
-          </ReviewCard.Actions>
-        </StyleCardReview>
-      </RecentReview>
+      <RecentReview />
       <AnimationSlide title="덕후들의 눈물샘을 터뜨린" animations={SlideAni} />
       <AnimationSlide title="이불밖을 못 나오게 하는" animations={SlideAni} />
       <Bottom>
@@ -229,72 +177,6 @@ const Container = styled.div`
   flex-direction: column;
   gap: 32px;
   padding-bottom: 66px;
-`;
-
-const DiscordContainer = styled.div`
-  width: 328px;
-  height: 80px;
-  margin: 0 auto;
-  border-radius: 5px;
-  background-color: ${({ theme }) => theme.colors["primary"]["60"]};
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: 0 18px;
-
-  span {
-    ${({ theme }) => theme.typo["title-2-b"]};
-    font-family: "Gmarket Sans";
-    line-height: 120%;
-  }
-
-  span:first-of-type {
-    color: ${({ theme }) => theme.colors["neutral"]["05"]};
-  }
-
-  span:last-of-type {
-    color: ${({ theme }) => theme.colors["neutral"]["10"]};
-  }
-
-  & > p {
-    ${({ theme }) => theme.typo["body-3-r"]};
-    color: ${({ theme }) => theme.colors["neutral"]["20"]};
-  }
-
-  & > svg {
-    width: 29px;
-    height: 22px;
-    position: absolute;
-    top: 29px;
-    right: 30px;
-  }
-`;
-
-const RecentReview = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  border-bottom: solid 1px ${({ theme }) => theme.colors["neutral"]["05"]};
-`;
-
-const Header = styled.div`
-  width: 100%;
-  padding: 0 16px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  & > h1 {
-    color: ${({ theme }) => theme.colors["neutral"]["100"]};
-    ${({ theme }) => theme.typo["title-2-m"]};
-  }
-`;
-
-const StyleCardReview = styled(ReviewCard)`
-  border-top: solid 2px ${({ theme }) => theme.colors["neutral"]["05"]};
-  border-bottom: solid 2px ${({ theme }) => theme.colors["neutral"]["05"]};
 `;
 
 const Bottom = styled.div`


### PR DESCRIPTION
## 📝 개요

https://github.com/oduck-team/oduck-client/assets/80813703/1bc3f761-d025-4b9e-9781-8dcbca97e61e

(placeholder, 오류 메시지는 촬영 후에 내용 변경되었습니다. 코드 참고해 주세요.)

- 닉네임 미설정 시 닉네임 설정 모달 띄우기
- 닉네임 설정 및 사용자 정보 업데이트
- 로그인 여부에 따라 후기 작성 버튼 클릭 시 해당 경로로 이동하게 함
    * 로그인 > 후기 작성 페이지
    * 미로그인 > 로그인 페이지


## 🚀 변경사항
랜딩 페이지 컴포넌트 일부를 분리했습니다.


## 🔗 관련 이슈

#41

## ➕ 기타

- placeholder와 오류 메시지는 gpt의 조언을 좀 받았는데 살짝 애매한 것 같기도 하네요. 의견이 있으시다면 반영하겠습니다.
- 그 외 코드 피드백 부탁드립니다.

+) 디스코드 박스는 클릭하면 저희 디코 서버 초대 링크로 이동하면 되는 걸까요? 알려주시면 감사하겠습니다.

<br/>
