### PR TITLE
refactor: view max-width

### DIFF
--- a/src/components/BottomNavigation/style.ts
+++ b/src/components/BottomNavigation/style.ts
@@ -7,6 +7,7 @@ export const Container = styled.nav`
   justify-content: center;
   bottom: 0;
   width: 100%;
+  max-width: 600px;
   height: 66px;
   background-color: white;
   box-shadow: 0px -4px 6px 0px rgba(0, 0, 0, 0.06);

--- a/src/components/BottomNavigation/style.ts
+++ b/src/components/BottomNavigation/style.ts
@@ -7,7 +7,7 @@ export const Container = styled.nav`
   justify-content: center;
   bottom: 0;
   width: 100%;
-  max-width: 600px;
+  max-width: ${({ theme }) => theme.maxWidth};
   height: 66px;
   background-color: white;
   box-shadow: 0px -4px 6px 0px rgba(0, 0, 0, 0.06);

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -92,6 +92,7 @@ export default function Layout() {
 const Container = styled.div`
   max-width: 600px;
   width: 100%;
+  height: 100%;
   margin: 0 auto;
 `;
 

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -90,7 +90,7 @@ export default function Layout() {
 }
 
 const Container = styled.div`
-  max-width: 600px;
+  max-width: ${({ theme }) => theme.maxWidth};
   width: 100%;
   height: 100%;
   margin: 0 auto;

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,3 +1,4 @@
+import styled from "@emotion/styled";
 import { HomeSimple, Menu, Search, Tv } from "iconoir-react";
 import { useEffect, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
@@ -72,7 +73,7 @@ export default function Layout() {
   }, [location]);
 
   return (
-    <>
+    <Container>
       <Outlet />
       <Sidebar
         isVisible={isSidebarVisible}
@@ -84,9 +85,15 @@ export default function Layout() {
         onClickItem={handleClickNav}
         items={bottomNavItems}
       />
-    </>
+    </Container>
   );
 }
+
+const Container = styled.div`
+  max-width: 600px;
+  width: 100%;
+  margin: 0 auto;
+`;
 
 function HomeFill() {
   return (

--- a/src/components/Stat/style.ts
+++ b/src/components/Stat/style.ts
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 
 import { StatProps, Variant } from "./index";
 
-function getStatStyle(theme: Theme, varient: Variant) {
+function getStatStyle(theme: Theme, variant: Variant) {
   const styles: Record<Variant, SerializedStyles> = {
     primary: css`
       box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.08);
@@ -21,7 +21,7 @@ function getStatStyle(theme: Theme, varient: Variant) {
     `,
   };
 
-  return styles[varient];
+  return styles[variant];
 }
 
 export const Container = styled.div<Pick<StatProps, "variant">>`

--- a/src/components/Tabs/style.ts
+++ b/src/components/Tabs/style.ts
@@ -7,7 +7,7 @@ export const TabTitles = styled.ul`
 `;
 export const TabTitle = styled.li<StyleProps>`
   display: flex;
-  width: 180px;
+  width: 100%;
   padding: 14px 10px;
   justify-content: center;
   align-items: center;

--- a/src/features/animations/routes/Detail/Hero.tsx
+++ b/src/features/animations/routes/Detail/Hero.tsx
@@ -52,7 +52,7 @@ export default function Hero({ animation }: AnimationHeroProps) {
       </Banner>
       <Actions>
         <Stat
-          varient="primary"
+          variant="primary"
           items={[
             { title: "별점", data: "★  4.8" },
             { title: "한줄리뷰", data: "111" },

--- a/src/features/animations/routes/List/index.tsx
+++ b/src/features/animations/routes/List/index.tsx
@@ -249,8 +249,8 @@ const Container = styled.div`
 
 export const HeaderContainer = styled.div`
   width: 100%;
+  max-width: 600px;
   position: fixed;
-  left: 0;
   top: 0;
 `;
 

--- a/src/features/animations/routes/List/index.tsx
+++ b/src/features/animations/routes/List/index.tsx
@@ -249,7 +249,7 @@ const Container = styled.div`
 
 export const HeaderContainer = styled.div`
   width: 100%;
-  max-width: 600px;
+  max-width: ${({ theme }) => theme.maxWidth};
   position: fixed;
   top: 0;
 `;
@@ -268,6 +268,7 @@ const Header = styled.div`
   & > svg {
     width: 24px;
     height: 24px;
+    cursor: pointer;
   }
 `;
 

--- a/src/features/auth/routes/Login/style.ts
+++ b/src/features/auth/routes/Login/style.ts
@@ -5,6 +5,8 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 export const Header = styled.header`
   position: sticky;
   top: 0;
+  max-width: 600px;
+  margin: 0 auto;
 `;
 
 export const HeaderContents = styled.div`

--- a/src/features/auth/routes/Login/style.ts
+++ b/src/features/auth/routes/Login/style.ts
@@ -5,7 +5,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 export const Header = styled.header`
   position: sticky;
   top: 0;
-  max-width: 600px;
+  max-width: ${({ theme }) => theme.maxWidth};
   margin: 0 auto;
 `;
 

--- a/src/styles/emotion.d.ts
+++ b/src/styles/emotion.d.ts
@@ -19,5 +19,6 @@ declare module "@emotion/react" {
     zIndex: ZIndex;
     mq: MediaQuery;
     container: Container;
+    maxWidth: string;
   }
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -17,4 +17,5 @@ export const theme: Theme = {
   zIndex,
   mq,
   container,
+  maxWidth: "600px", // pc 작업 이전 임시 view max-width
 };


### PR DESCRIPTION
## 📝 개요

view max-width 600px 설정




https://github.com/oduck-team/oduck-client/assets/80813703/db6b69df-e803-4586-89aa-9299f8d784be



## 🚀 변경사항

- tab width 수정
- stats variant 오타 수정
- layout Container 추가

```typescript
// layout/index.tsx

  return (
    <Container>
      <Outlet />
      <Sidebar ... />
      <BottomNavigation ... />
    </Container>
  );
}

const Container = styled.div`
  max-width: 600px;
  width: 100%;
  height: 100%;
  margin: 0 auto;
`;
```

## 🔗 관련 이슈

#28 #137

## ➕ 기타

- 로그인 페이지는 Responsive Container와 media query 스타일이 있어서 Header 제외한 Content 부분은 손대지 않았습니다.

<img src="https://github.com/oduck-team/oduck-client/assets/80813703/6d01cf46-64c6-4e2f-92ef-199587b69b74" width="300px"/>
<img src="https://github.com/oduck-team/oduck-client/assets/80813703/da20b69d-8dc1-4547-a9fb-ea0be99447df" width="400px"/> <br />

<br />

- Backdrop 스타일은 변경 사항이 없어 사이드바 위치도 그대로 right 0 입니다.
<img src="https://github.com/oduck-team/oduck-client/assets/80813703/f03940c8-046e-42ad-b905-87b364b288cf" width="400px"/> <br />


- 애니 리스트 BottomSheet 부분 스타일은 추후 수정 예정입니다.

빠진 부분이나 의견 있으시면 코멘트 남겨주세요.

<br />