### PR TITLE
feat: 공통 헤더 컴포넌트

### DIFF
--- a/src/components/Layout/Header.style.ts
+++ b/src/components/Layout/Header.style.ts
@@ -1,0 +1,43 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.header`
+  position: sticky;
+  top: 0;
+  width: 100%;
+  max-width: ${({ theme }) => theme.maxWidth};
+  margin: 0 auto;
+  background-color: #fff;
+
+  & h1 {
+    ${({ theme }) => theme.typo["title-3-m"]}
+  }
+`;
+
+export const Contents = styled.div`
+  ${({ theme }) => theme.container}
+  display: flex;
+  height: 60px;
+  padding: 0 16px;
+  margin: 0 auto;
+
+  & > div {
+    width: calc(100% / 3);
+  }
+`;
+
+export const Left = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const Center = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Right = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: end;
+`;

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,0 +1,19 @@
+import { StrictPropsWithChildren } from "@/types";
+
+import { Center, Container, Contents, Left, Right } from "./Header.style";
+
+/**
+ * 공통 헤더 컴포넌트입니다
+ * Left, Center, Right를 조합하여 사용합니다
+ */
+export default function Header({ children }: StrictPropsWithChildren) {
+  return (
+    <Container>
+      <Contents>{children}</Contents>
+    </Container>
+  );
+}
+
+Header.Left = Left;
+Header.Center = Center;
+Header.Right = Right;

--- a/src/features/animations/routes/List/index.tsx
+++ b/src/features/animations/routes/List/index.tsx
@@ -1,10 +1,11 @@
 import styled from "@emotion/styled";
-import { Cancel, Filter, NavArrowLeft } from "iconoir-react";
+import { Cancel, Filter } from "iconoir-react";
 import { useState } from "react";
 
 import BottomSheet from "@/components/BottomSheet";
 import Button from "@/components/Button";
 import Chip from "@/components/Chip";
+import Header from "@/components/Layout/Header";
 import Tabs from "@/components/Tabs";
 import AnimationCard from "@/features/animations/components/AnimationCard";
 import { Animation } from "@/features/animations/components/AnimationCarousel";
@@ -105,14 +106,16 @@ export default function AnimationList() {
 
   return (
     <Container>
-      <HeaderContainer>
-        <Header>
-          <NavArrowLeft />
-          애니
+      <Header>
+        <Header.Left />
+        <Header.Center>
+          <h1>애니</h1>
+        </Header.Center>
+        <Header.Right>
           <Filter onClick={() => setBottomSheetVisible(true)} />
-        </Header>
-        <Tabs items={items} defaultActiveId={1} />
-      </HeaderContainer>
+        </Header.Right>
+      </Header>
+      <Tabs items={items} defaultActiveId={1} />
       <Content>
         <AnimationCard size="lg" ani={CardAni} />
         <AnimationCard size="lg" ani={CardAni2} />
@@ -254,24 +257,6 @@ export const HeaderContainer = styled.div`
   max-width: ${({ theme }) => theme.maxWidth};
   position: fixed;
   top: 0;
-`;
-
-const Header = styled.div`
-  background-color: white;
-  width: 100%;
-  height: 90px;
-  padding: 40px 16px 0;
-  flex-shrink: 0;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  ${({ theme }) => theme.typo["title-3-b"]};
-
-  & > svg {
-    width: 24px;
-    height: 24px;
-    cursor: pointer;
-  }
 `;
 
 const Content = styled.div`

--- a/src/features/auth/routes/Login/index.tsx
+++ b/src/features/auth/routes/Login/index.tsx
@@ -2,11 +2,12 @@ import { NavArrowLeft } from "iconoir-react";
 
 import Button from "@/components/Button";
 import Head from "@/components/Head";
+import Header from "@/components/Layout/Header";
 
 import useLogin from "../../hooks/useLogin";
 
 import SocialGroup from "./SocialGroup";
-import { Header, HeaderContents, Main, Title, LoginSection } from "./style";
+import { Main, Title, LoginSection } from "./style";
 
 export default function Login() {
   const { handleClickBack, handleSocialLogin } = useLogin();
@@ -18,7 +19,7 @@ export default function Login() {
         description="오덕에 회원가입 없이 빠르게 덕질을 시작해 보세요!"
       />
       <Header>
-        <HeaderContents>
+        <Header.Left>
           <Button
             name="뒤로가기"
             icon={<NavArrowLeft aria-hidden />}
@@ -26,8 +27,10 @@ export default function Login() {
             color="neutral"
             onClick={handleClickBack}
           />
+        </Header.Left>
+        <Header.Center>
           <h1>로그인</h1>
-        </HeaderContents>
+        </Header.Center>
       </Header>
       <Main htmlType={"main"}>
         <Title>

--- a/src/features/auth/routes/Login/style.ts
+++ b/src/features/auth/routes/Login/style.ts
@@ -2,32 +2,6 @@ import styled from "@emotion/styled";
 
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 
-export const Header = styled.header`
-  position: sticky;
-  top: 0;
-  max-width: ${({ theme }) => theme.maxWidth};
-  margin: 0 auto;
-`;
-
-export const HeaderContents = styled.div`
-  ${({ theme }) => theme.container}
-  display: flex;
-  align-items: center;
-  height: 50px;
-  padding: 0 1rem;
-  margin: 0 auto;
-
-  & > h1 {
-    ${({ theme }) => theme.typo["title-3-m"]}
-    margin: 0 auto;
-  }
-
-  & > button {
-    position: absolute;
-    margin-left: 0;
-  }
-`;
-
 export const Main = styled(ResponsiveContainer)`
   position: relative;
   display: flex;

--- a/src/features/common/routes/HelpDesk/Form.tsx
+++ b/src/features/common/routes/HelpDesk/Form.tsx
@@ -1,9 +1,10 @@
 import { NavArrowLeft } from "iconoir-react";
 
 import Button from "@/components/Button";
+import Header from "@/components/Layout/Header";
 
 import { Content, FormItem, FormTextInput, FormTextarea } from "./Form.style";
-import { Container, Header } from "./Select.style";
+import { Container } from "./Select.style";
 import useForm from "./useForm";
 
 interface Props {
@@ -38,8 +39,12 @@ export default function Form({ goPrev, inquiryTypeName, setSuccess }: Props) {
   return (
     <Container>
       <Header>
-        <NavArrowLeft onClick={handlerPrevClick} />
-        {inquiryTypeName}
+        <Header.Left>
+          <NavArrowLeft onClick={handlerPrevClick} />
+        </Header.Left>
+        <Header.Center>
+          <h1>{inquiryTypeName}</h1>
+        </Header.Center>
       </Header>
       <Content>
         <FormItem>

--- a/src/features/common/routes/HelpDesk/Select.style.ts
+++ b/src/features/common/routes/HelpDesk/Select.style.ts
@@ -1,28 +1,5 @@
 import styled from "@emotion/styled";
 
-export const Header = styled.div`
-  background-color: white;
-  width: 100%;
-  height: 90px;
-  padding: 40px 16px 0;
-  flex-shrink: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-  ${({ theme }) => theme.typo["title-3-b"]};
-  color: ${({ theme }) => theme.colors["neutral"]["80"]};
-
-  & > svg {
-    width: 24px;
-    height: 24px;
-    position: absolute;
-    left: 17px;
-    color: ${({ theme }) => theme.colors["neutral"]["90"]};
-    cursor: pointer;
-  }
-`;
-
 export const Container = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/features/common/routes/HelpDesk/Select.tsx
+++ b/src/features/common/routes/HelpDesk/Select.tsx
@@ -2,8 +2,9 @@ import { NavArrowLeft } from "iconoir-react";
 import { useNavigate } from "react-router-dom";
 
 import Button from "@/components/Button";
+import Header from "@/components/Layout/Header";
 
-import { Buttons, Container, Content, Header } from "./Select.style";
+import { Buttons, Container, Content } from "./Select.style";
 
 interface Props {
   inquiryTypeName: string[];
@@ -16,8 +17,10 @@ export default function Select({ inquiryTypeName, onClick }: Props) {
   return (
     <Container>
       <Header>
-        <NavArrowLeft onClick={() => navigate(-1)} />
-        고객센터
+        <Header.Left>
+          <NavArrowLeft onClick={() => navigate(-1)} />
+        </Header.Left>
+        <Header.Center>고객센터</Header.Center>
       </Header>
       <Content>
         <div>

--- a/src/features/common/routes/HelpDesk/Success.tsx
+++ b/src/features/common/routes/HelpDesk/Success.tsx
@@ -2,15 +2,21 @@ import styled from "@emotion/styled";
 import { useNavigate } from "react-router-dom";
 
 import Button from "@/components/Button";
+import Header from "@/components/Layout/Header";
 
-import { Container as BaseContainer, Content, Header } from "./Select.style";
+import { Container as BaseContainer, Content } from "./Select.style";
 
 export default function Success() {
   const navigate = useNavigate();
 
   return (
     <Container>
-      <Header>발송 완료</Header>
+      <Header>
+        <Header.Left />
+        <Header.Center>
+          <h1>발송 완료</h1>
+        </Header.Center>
+      </Header>
       <Content>
         <div>
           <h1>문의가 완료되었습니다.</h1>

--- a/src/features/common/routes/Search/index.tsx
+++ b/src/features/common/routes/Search/index.tsx
@@ -5,6 +5,7 @@ import { ComponentProps, useState } from "react";
 import Button from "@/components/Button";
 import Chip from "@/components/Chip";
 import Head from "@/components/Head";
+import Header from "@/components/Layout/Header";
 import AnimationCard from "@/features/animations/components/AnimationCard";
 
 const 최근_많이_검색된 = [
@@ -68,15 +69,19 @@ export default function Search() {
   return (
     <>
       <Head title="오덕 | 검색하기" />
+
       <Container>
+        <Header>
+          <Header.Center style={{ width: "100%" }}>
+            <Searchbar
+              value={searchInputValue}
+              onChange={handleSearchChange}
+              onSearch={handleSearch}
+              onCancel={handleSearchCancel}
+            />
+          </Header.Center>
+        </Header>
         <h1>검색하기</h1>
-        <Searchbar
-          value={searchInputValue}
-          style={{ marginTop: "50px" }}
-          onChange={handleSearchChange}
-          onSearch={handleSearch}
-          onCancel={handleSearchCancel}
-        />
         <Section style={{ marginTop: "32px" }}>
           <h1>최근 많이 검색된</h1>
           <ul
@@ -113,7 +118,6 @@ export default function Search() {
 const Container = styled.main`
   ${({ theme }) => theme.container}
   margin: 0 auto;
-  padding: 0 16px;
 
   & > h1 {
     display: none;
@@ -170,6 +174,7 @@ function Searchbar({
 
 const SearchbarContainer = styled.div<{ isButtonVisible: boolean }>`
   position: relative;
+  width: 100%;
 
   & > svg {
     position: absolute;
@@ -220,6 +225,8 @@ const SearchbarContainer = styled.div<{ isButtonVisible: boolean }>`
 `;
 
 const Section = styled.section`
+  padding: 0 16px;
+
   & > h1 {
     ${({ theme }) => theme.typo["title-3-m"]}
     color: ${({ theme }) => theme.colors.neutral["80"]};


### PR DESCRIPTION
## 📝 개요
- 디자인 fix된 공통 헤더 컴포넌트 구현
```tsx
<Header>
  <Header.Left>...</Header.Left>
  <Header.Center>...</Header.Center>
  <Header.Right>...</Header.Right>
</Header>
```
<img width="389" alt="스크린샷 2023-09-26 오전 12 42 43" src="https://github.com/oduck-team/oduck-client/assets/105474635/871c7fc6-fa09-4acb-892d-83922ea2b27d">

<img width="389" alt="스크린샷 2023-09-26 오전 12 43 23" src="https://github.com/oduck-team/oduck-client/assets/105474635/e0acaafc-8dbe-4907-a89c-f738a91b4eda">
<img width="389" alt="스크린샷 2023-09-26 오전 12 43 19" src="https://github.com/oduck-team/oduck-client/assets/105474635/dfd545db-c74e-4369-833b-5df3c66b5864">
<img width="389" alt="스크린샷 2023-09-26 오전 12 42 52" src="https://github.com/oduck-team/oduck-client/assets/105474635/faad439c-1ccb-4ef1-8873-0af1dcb6f91c">
<img width="389" alt="스크린샷 2023-09-26 오전 12 42 49" src="https://github.com/oduck-team/oduck-client/assets/105474635/50e5a0ff-72fd-4bf2-b3ed-e730242fd938">



## 🚀 변경사항
다음 페이지에 반영
- 로그인
- 고객센터
- 애니 리스트
- 검색

## 🔗 관련 이슈

#145 

## ➕ 기타

고객센터에서 화면 전환시 슬라이드 애니메이션이 있는데, 헤더에는 빠지는게 자연스럽게 느껴지네요 🤔

