### PR TITLE
fix: 페이지 전환이 로딩 중일 경우 drawer가 닫히지 않는 현상

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -51,18 +51,29 @@ const helpMenuItems: NavItem[] = [
 
 interface SidebarProps {
   isVisible: boolean;
+  onClickItem: () => void;
   onClose: () => void;
 }
 
-export default function Sidebar({ isVisible, onClose }: SidebarProps) {
+export default function Sidebar({
+  isVisible,
+  onClickItem,
+  onClose,
+}: SidebarProps) {
   const { user, isLoggedIn, logout } = useAuth();
   const navigate = useNavigate();
 
   const handleClickUserMenu = (id: string, e: React.MouseEvent) => {
     e.preventDefault();
+
     if (!isLoggedIn) navigate("/login", { replace: true });
+
     const foundItem = userMenuItems.find((item) => item.id === id);
-    if (foundItem) navigate(foundItem.to);
+
+    if (foundItem) {
+      onClickItem();
+      navigate(foundItem.to);
+    }
   };
 
   const handleLogout = (_id: string, e: React.MouseEvent) => {
@@ -120,7 +131,7 @@ export default function Sidebar({ isVisible, onClose }: SidebarProps) {
         <Divider />
         <Navigation.Content>
           {helpMenuItems.map((item) => (
-            <Navigation.Item key={item.id} item={item} />
+            <Navigation.Item key={item.id} item={item} onClick={onClickItem} />
           ))}
           {isLoggedIn && (
             <Navigation.Item

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { HomeSimple, Menu, Search, Tv } from "iconoir-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import BottomNavigation, { INavigationItem } from "../BottomNavigation";
@@ -67,6 +67,10 @@ export default function Layout() {
       }
     }
   };
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   return (
     <Container>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { HomeSimple, Menu, Search, Tv } from "iconoir-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import BottomNavigation, { INavigationItem } from "../BottomNavigation";
@@ -68,15 +68,12 @@ export default function Layout() {
     }
   };
 
-  useEffect(() => {
-    handleSidebarVisible(false);
-  }, [location]);
-
   return (
     <Container>
       <Outlet />
       <Sidebar
         isVisible={isSidebarVisible}
+        onClickItem={() => handleSidebarVisible(false)}
         onClose={() => handleSidebarVisible(false)}
       />
       <BottomNavigation

--- a/src/features/animations/routes/List/index.tsx
+++ b/src/features/animations/routes/List/index.tsx
@@ -264,7 +264,7 @@ const Content = styled.div`
   display: flex;
   flex-direction: column;
   gap: 32px;
-  padding: 166px 16px 92px;
+  padding: 24px 16px 92px;
 `;
 
 const ChipsContiner = styled.div`


### PR DESCRIPTION
## 📝 개요

페이지 전환중 로딩일 경우 Drawer가 바로 닫히지 않는 현상이 있어 수정했습니다

## 🚀 변경사항

`useEffect`로 location 변경이 일어나면 닫히는게 아닌 side bar의 item 클릭시 닫히도록 변경

## 🔗 관련 이슈

 #151

## ➕ 기타



