### PR TITLE
refactor: 고객센터 form 구조 변경

### DIFF
--- a/src/features/common/routes/HelpDesk/Form.tsx
+++ b/src/features/common/routes/HelpDesk/Form.tsx
@@ -11,21 +11,7 @@ interface Props {
 }
 
 export default function Form({ setSuccess }: Props) {
-  const {
-    email,
-    title,
-    inquiryContent,
-    emailError,
-    titleError,
-    contentError,
-    emailErrorMessage,
-    titleErrorMessage,
-    contentErrorMessage,
-    handleEmailChange,
-    handleTitleChange,
-    handleContentChange,
-    send,
-  } = useForm();
+  const { form, error, handleInputChange, errorMessage, send } = useForm();
 
   return (
     <Container>
@@ -33,35 +19,38 @@ export default function Form({ setSuccess }: Props) {
         <FormItem>
           <h4>보내는 사람</h4>
           <FormTextInput
-            value={email}
+            value={form.email}
             type="email"
+            name="email"
             placeholder="이메일을 입력해 주세요."
-            onChange={handleEmailChange}
-            warn={Boolean(emailError)}
-            message={emailError ? emailErrorMessage[emailError] : ""}
+            onChange={handleInputChange}
+            warn={Boolean(error.email)}
+            message={error.email ? errorMessage.email[error.email] : ""}
             required
           />
         </FormItem>
         <FormItem>
           <h4>문의 제목</h4>
           <FormTextInput
-            value={title}
+            value={form.title}
             type="text"
+            name="title"
             placeholder="제목을 입력해 주세요.(최대 50자)"
-            onChange={handleTitleChange}
-            warn={Boolean(titleError)}
-            message={titleError ? titleErrorMessage[titleError] : ""}
+            onChange={handleInputChange}
+            warn={Boolean(error.title)}
+            message={error.title ? errorMessage.title[error.title] : ""}
             required
           />
         </FormItem>
         <FormItem textarea>
           <h4>문의 내용</h4>
           <FormTextarea
-            value={inquiryContent}
-            onChange={handleContentChange}
+            value={form.content}
+            name="content"
+            onChange={handleInputChange}
             placeholder="내용을 입력해 주세요.(최대 1,000자)"
-            warn={Boolean(contentError)}
-            message={contentError ? contentErrorMessage[contentError] : ""}
+            warn={Boolean(error.content)}
+            message={error.content ? errorMessage.content[error.content] : ""}
             required
           />
         </FormItem>

--- a/src/features/common/routes/HelpDesk/useForm.ts
+++ b/src/features/common/routes/HelpDesk/useForm.ts
@@ -31,14 +31,16 @@ export default function useForm() {
 
     for (const key in form) {
       setError((prev) => ({ ...prev, [key]: 0 }));
-      if ((form as Record<string, string>)[key].length === 0) {
+      if ((form as Record<string, string>)[key].trim().length === 0) {
         setError((prev) => ({ ...prev, [key]: 1 }));
       } else if (key === "email" && !emailPattern.test(form[key]))
         setError((prev) => ({ ...prev, [key]: 2 }));
     }
 
     const ok =
-      emailPattern.test(form.email) && form.title !== "" && form.content !== "";
+      emailPattern.test(form.email) &&
+      form.title.trim().length !== 0 &&
+      form.content.trim().length !== 0;
 
     if (ok) {
       // TODO: API 요청

--- a/src/features/common/routes/HelpDesk/useForm.ts
+++ b/src/features/common/routes/HelpDesk/useForm.ts
@@ -6,22 +6,18 @@ export default function useForm() {
 
   const errorMessage = {
     email: ["", "이메일을 입력해 주세요.", "이메일 형식이 올바르지 않습니다."],
-    title: [
-      "",
-      "문의 제목을 입력해 주세요.",
-      "문의 제목을 50자 내로 입력해 주세요.",
-    ],
-    content: [
-      "",
-      "문의 내용을 입력해 주세요.",
-      "문의 내용을 1000자 내로 입력해 주세요.",
-    ],
+    title: ["", "문의 제목을 입력해 주세요."],
+    content: ["", "문의 내용을 입력해 주세요."],
   };
 
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { name, value } = e.target;
+
+    if (name === "title" && value.length > 50) return;
+    if (name === "content" && value.length > 1000) return;
+
     setForm((prev) => ({ ...prev, [name]: value }));
   };
 
@@ -37,22 +33,12 @@ export default function useForm() {
       setError((prev) => ({ ...prev, [key]: 0 }));
       if ((form as Record<string, string>)[key].length === 0) {
         setError((prev) => ({ ...prev, [key]: 1 }));
-      } else {
-        if (key === "email" && !emailPattern.test(form[key]))
-          setError((prev) => ({ ...prev, [key]: 2 }));
-        if (key === "title" && form[key].length > 50)
-          setError((prev) => ({ ...prev, [key]: 2 }));
-        if (key === "content" && form[key].length > 1000)
-          setError((prev) => ({ ...prev, [key]: 2 }));
-      }
+      } else if (key === "email" && !emailPattern.test(form[key]))
+        setError((prev) => ({ ...prev, [key]: 2 }));
     }
 
     const ok =
-      emailPattern.test(form.email) &&
-      form.title !== "" &&
-      form.title.length <= 50 &&
-      form.content !== "" &&
-      form.content.length <= 1000;
+      emailPattern.test(form.email) && form.title !== "" && form.content !== "";
 
     if (ok) {
       // TODO: API 요청

--- a/src/features/common/routes/HelpDesk/useForm.ts
+++ b/src/features/common/routes/HelpDesk/useForm.ts
@@ -1,77 +1,58 @@
 import { useState } from "react";
 
 export default function useForm() {
-  const [email, setEmail] = useState("");
-  const [title, setTitle] = useState("");
-  const [inquiryContent, setInquiryContent] = useState("");
+  const [form, setForm] = useState({ email: "", title: "", content: "" });
+  const [error, setError] = useState({ email: 0, title: 0, content: 0 });
 
-  const [emailError, setEmailError] = useState<number>(0);
-  const [titleError, setTitleError] = useState<number>(0);
-  const [contentError, setContentError] = useState<number>(0);
-
-  const emailErrorMessage = [
-    "",
-    "이메일을 입력해 주세요.",
-    "이메일 형식이 올바르지 않습니다.",
-  ];
-
-  const titleErrorMessage = [
-    "",
-    "문의 제목을 입력해 주세요.",
-    "문의 제목을 50자 내로 입력해 주세요.",
-  ];
-
-  const contentErrorMessage = [
-    "",
-    "문의 내용을 입력해 주세요.",
-    "문의 내용을 1000자 내로 입력해 주세요.",
-  ];
-
-  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setEmail(e.target.value);
+  const errorMessage = {
+    email: ["", "이메일을 입력해 주세요.", "이메일 형식이 올바르지 않습니다."],
+    title: [
+      "",
+      "문의 제목을 입력해 주세요.",
+      "문의 제목을 50자 내로 입력해 주세요.",
+    ],
+    content: [
+      "",
+      "문의 내용을 입력해 주세요.",
+      "문의 내용을 1000자 내로 입력해 주세요.",
+    ],
   };
 
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTitle(e.target.value);
-  };
-
-  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setInquiryContent(e.target.value);
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
   };
 
   const resetForm = () => {
-    setEmail("");
-    setTitle("");
-    setInquiryContent("");
-    setEmailError(0);
-    setTitleError(0);
-    setContentError(0);
+    setForm({ email: "", title: "", content: "" });
+    setError({ email: 0, title: 0, content: 0 });
   };
 
   const send = (setSuccess: React.Dispatch<React.SetStateAction<boolean>>) => {
     const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
-    setEmailError(() => {
-      if (email === "") return 1;
-      else if (!emailPattern.test(email)) return 2;
-      else return 0;
-    });
-    setTitleError(() => {
-      if (title === "") return 1;
-      else if (title.length > 50) return 2;
-      else return 0;
-    });
-    setContentError(() => {
-      if (inquiryContent === "") return 1;
-      else if (inquiryContent.length > 1000) return 2;
-      else return 0;
-    });
+
+    for (const key in form) {
+      setError((prev) => ({ ...prev, [key]: 0 }));
+      if ((form as Record<string, string>)[key].length === 0) {
+        setError((prev) => ({ ...prev, [key]: 1 }));
+      } else {
+        if (key === "email" && !emailPattern.test(form[key]))
+          setError((prev) => ({ ...prev, [key]: 2 }));
+        if (key === "title" && form[key].length > 50)
+          setError((prev) => ({ ...prev, [key]: 2 }));
+        if (key === "content" && form[key].length > 1000)
+          setError((prev) => ({ ...prev, [key]: 2 }));
+      }
+    }
 
     const ok =
-      emailPattern.test(email) &&
-      title !== "" &&
-      title.length <= 50 &&
-      inquiryContent !== "" &&
-      inquiryContent.length <= 1000;
+      emailPattern.test(form.email) &&
+      form.title !== "" &&
+      form.title.length <= 50 &&
+      form.content !== "" &&
+      form.content.length <= 1000;
 
     if (ok) {
       // TODO: API 요청
@@ -82,18 +63,10 @@ export default function useForm() {
   };
 
   return {
-    email,
-    title,
-    inquiryContent,
-    emailError,
-    titleError,
-    contentError,
-    emailErrorMessage,
-    titleErrorMessage,
-    contentErrorMessage,
-    handleEmailChange,
-    handleTitleChange,
-    handleContentChange,
+    form,
+    error,
+    errorMessage,
+    handleInputChange,
     resetForm,
     send,
   };


### PR DESCRIPTION
## 📝 개요

고객센터 form 구조 변경

<img src="https://github.com/oduck-team/oduck-client/assets/80813703/594435c1-897c-4424-968d-2694640672d0" width="450px"/>

- email, title, content 따로 다루었던 것을 form 객체로 합침
- form의 각 항목에 대한 error 따로 다루었던 것을 error 객체로 합침
- errorMessage 객체로 합침

<br/>

## 🚀 변경사항

## 🔗 관련 이슈

#174
<br/>
## ➕ 기타

잘못된 부분이나 개선할 부분이 있다면 알려주세요~~
<br/>
