### PR TITLE
refactor: 디자인 피드백 반영

### DIFF
--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -79,7 +79,7 @@ export default function BottomSheet({
         dragConstraints={{ top: 0, bottom: 0 }}
         dragListener={false}
         dragControls={dragControls}
-        dragElastic={0.2} // 외부 제약을 허용하는 조건(제약 범위를 벗어날수록 돌아가려는 움직임의 정도)
+        dragElastic={0.5} // 외부 제약을 허용하는 조건(제약 범위를 벗어날수록 돌아가려는 움직임의 정도)
         onDrag={handleDrag}
         onDragEnd={handleDragEnd}
         onClick={(e) => e.stopPropagation()}

--- a/src/features/animations/routes/Detail/Ratings.style.ts
+++ b/src/features/animations/routes/Detail/Ratings.style.ts
@@ -1,5 +1,28 @@
 import styled from "@emotion/styled";
 
+export const AverageRatings = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+`;
+
+export const AverageRatingsOverview = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+
+  & > span {
+    font-size: 32px;
+    font-weight: 500;
+    letter-spacing: -1.6px;
+
+    & > svg {
+      color: ${({ theme }) => theme.colors.secondary["50"]};
+    }
+  }
+`;
+
 export const AttractionPoint = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/features/animations/routes/Detail/Ratings.tsx
+++ b/src/features/animations/routes/Detail/Ratings.tsx
@@ -1,7 +1,11 @@
+import { Star } from "@phosphor-icons/react";
+
 import Progress from "@/components/Progress";
 import Rating from "@/components/Rating";
 
 import {
+  AverageRatings,
+  AverageRatingsOverview,
   AttractionPoint,
   AttractionPointLabel,
   AttractionPointRatio,
@@ -13,17 +17,13 @@ export default function Ratings() {
   return (
     <Section>
       <h1>평점</h1>
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-        }}
-      >
-        <div style={{ display: "flex", justifyContent: "center", gap: "8px" }}>
-          <span style={{ fontSize: "32px" }}>😆</span>
-          <span style={{ fontSize: "32px", fontWeight: "bold" }}>4.2</span>
-        </div>
+      <AverageRatings>
+        <AverageRatingsOverview>
+          <span>
+            <Star size={36} weight="fill" />
+          </span>
+          <span>4.2</span>
+        </AverageRatingsOverview>
         <Rating
           readonly
           style={{
@@ -32,7 +32,7 @@ export default function Ratings() {
             marginLeft: "auto",
           }}
         />
-      </div>
+      </AverageRatings>
 
       <AttractionPoint>
         <h2>입덕포인트</h2>

--- a/src/features/animations/routes/List/style.ts
+++ b/src/features/animations/routes/List/style.ts
@@ -24,5 +24,5 @@ export const Content = styled.div`
   display: flex;
   flex-direction: column;
   gap: 32px;
-  padding: 74px 16px 24px;
+  padding: 24px 16px;
 `;

--- a/src/features/common/routes/Search/Searchbar/style.ts
+++ b/src/features/common/routes/Search/Searchbar/style.ts
@@ -21,6 +21,7 @@ export const SearchbarContainer = styled.div<{ isButtonVisible: boolean }>`
   }
 
   & input[type="text"] {
+    ${({ theme }) => theme.typo["body-2-m"]}
     display: inline-flex;
     align-items: center;
     height: 40px;

--- a/src/features/notices/routes/List/NoticeAccordion/style.ts
+++ b/src/features/notices/routes/List/NoticeAccordion/style.ts
@@ -27,6 +27,7 @@ export const ToggleButton = styled.button`
   justify-content: center;
   background-color: transparent;
   border: none;
+  color: ${({ theme }) => theme.colors.neutral["90"]};
   cursor: pointer;
 `;
 

--- a/src/features/reviews/components/AttractionPoint/style.ts
+++ b/src/features/reviews/components/AttractionPoint/style.ts
@@ -4,7 +4,7 @@ export const AttractionPointContainer = styled.label<{ isChecked: boolean }>`
   ${({ theme }) => theme.typo["body-3-r"]}
   display: flex;
   align-items: center;
-  height: 32px;
+  height: 40px;
   padding-left: 16px;
   background-color: ${({ theme, isChecked }) =>
     isChecked ? theme.colors.primary["50"] : theme.colors.neutral["05"]};

--- a/src/features/reviews/components/ReviewRating/ShortReviewModal.style.ts
+++ b/src/features/reviews/components/ReviewRating/ShortReviewModal.style.ts
@@ -36,7 +36,7 @@ export const AttractionPointSection = styled.div`
   }
 
   & span {
-    color: ${({ theme }) => theme.colors.secondary["70"]};
+    color: ${({ theme }) => theme.colors.primary["60"]};
   }
 `;
 


### PR DESCRIPTION
## 📝 개요

어제 회의로 진행된 디자인 피드백 반영

## 🚀 변경사항

- 공지사항 리스트 페이지 : ios safari에서 토글 버튼 (`>`) primary 색을 neutral로 수정
- 한 줄 리뷰 모달
  - 입덕 포인트 체크박스 높이 32px -> 40px로 수정
  - 입덕 포인트 안내 문구 primary로 변경
- bottom sheet 터치 드래그 느낌을 부드럽게 하기위해 dragElastic 값 수정 
- 애니 목록 페이지 헤더와 컨텐츠간 간격(padding) 축소 수정
- 검색페이지 : 검색바 ios safari font size가 작게나와 값 설정
- 애니 상세 페이지 중단의 평균 평점 간격 수정

## 🔗 관련 이슈

#201

## ➕ 기타



