### PR TITLE
모달 컴포넌트의 state가 유지되지 않도록 수정한다.

### DIFF
--- a/src/components/Backdrop/index.tsx
+++ b/src/components/Backdrop/index.tsx
@@ -13,7 +13,10 @@ export interface BackdropProps {
   onClick: () => void;
 }
 
-/** AnimatePortal 컴포넌트로 감싸서 사용 */
+/**
+ * @desc 1. < AnimatePortal > 컴포넌트와 함께 사용
+ * @desc 2. < AnimatePresence > + <Portal> 컴포넌트와 함께 사용
+ * */
 export default function Backdrop({
   isVisible = true,
   className = "",

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -3,8 +3,6 @@ import { Variants } from "framer-motion";
 import useScrollLock from "@/hooks/useScrollLock";
 import { StrictPropsWithChildren } from "@/types";
 
-import AnimatePortal from "../Portal/AnimatePortal";
-
 import ModalActions from "./ModalActions";
 import ModalContent from "./ModalContent";
 import { Backdrop, ModalContainer } from "./style";
@@ -32,7 +30,7 @@ export default function Modal({
   useScrollLock(isVisible);
 
   return (
-    <AnimatePortal isVisible={isVisible}>
+    <>
       <Backdrop isVisible={showBackdrop} onClick={onClose} />
       <ModalContainer
         aria-modal={isVisible}
@@ -46,7 +44,7 @@ export default function Modal({
       >
         {children}
       </ModalContainer>
-    </AnimatePortal>
+    </>
   );
 }
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -23,7 +23,7 @@ export interface ModalProps {
 }
 
 export default function Modal({
-  isVisible = false,
+  isVisible = true,
   size = "default",
   showBackdrop = true,
   onClose,

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -22,6 +22,7 @@ export interface ModalProps {
   onClose: () => void;
 }
 
+/** @desc < AnimatePresence > 컴포넌트로 감싸서 사용해주세요. */
 export default function Modal({
   isVisible = true,
   size = "default",

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -3,6 +3,8 @@ import { Variants } from "framer-motion";
 import useScrollLock from "@/hooks/useScrollLock";
 import { StrictPropsWithChildren } from "@/types";
 
+import Portal from "../Portal";
+
 import ModalActions from "./ModalActions";
 import ModalContent from "./ModalContent";
 import { Backdrop, ModalContainer } from "./style";
@@ -30,7 +32,7 @@ export default function Modal({
   useScrollLock(isVisible);
 
   return (
-    <>
+    <Portal>
       <Backdrop isVisible={showBackdrop} onClick={onClose} />
       <ModalContainer
         aria-modal={isVisible}
@@ -44,7 +46,7 @@ export default function Modal({
       >
         {children}
       </ModalContainer>
-    </>
+    </Portal>
   );
 }
 

--- a/src/components/SnackBar/index.tsx
+++ b/src/components/SnackBar/index.tsx
@@ -1,4 +1,5 @@
-import { forwardRef } from "react";
+import { usePresence } from "framer-motion";
+import { forwardRef, useEffect } from "react";
 
 import { SnackBarContainer } from "./style";
 
@@ -6,8 +7,14 @@ interface SnackBarProps {
   text: string;
 }
 
+//TODO: SnackBar animation 변경
 const SnackBar = forwardRef(
   ({ text }: SnackBarProps, ref: React.ForwardedRef<HTMLDivElement>) => {
+    const [isPresent, safeToRemove] = usePresence();
+    useEffect(() => {
+      !isPresent && setTimeout(safeToRemove, 2000);
+    }, [isPresent, safeToRemove]);
+
     return <SnackBarContainer ref={ref}>{text}</SnackBarContainer>;
   },
 );

--- a/src/components/SnackBar/index.tsx
+++ b/src/components/SnackBar/index.tsx
@@ -1,5 +1,4 @@
-import { usePresence } from "framer-motion";
-import { forwardRef, useEffect } from "react";
+import { forwardRef } from "react";
 
 import { SnackBarContainer } from "./style";
 
@@ -10,10 +9,10 @@ interface SnackBarProps {
 //TODO: SnackBar animation 변경
 const SnackBar = forwardRef(
   ({ text }: SnackBarProps, ref: React.ForwardedRef<HTMLDivElement>) => {
-    const [isPresent, safeToRemove] = usePresence();
-    useEffect(() => {
-      !isPresent && setTimeout(safeToRemove, 2000);
-    }, [isPresent, safeToRemove]);
+    // const [isPresent, safeToRemove] = usePresence();
+    // useEffect(() => {
+    //   !isPresent && setTimeout(safeToRemove, 2000);
+    // }, [isPresent, safeToRemove]);
 
     return <SnackBarContainer ref={ref}>{text}</SnackBarContainer>;
   },

--- a/src/features/auth/components/LoginAlertModal/index.tsx
+++ b/src/features/auth/components/LoginAlertModal/index.tsx
@@ -7,14 +7,10 @@ import useRedirect from "@/hooks/useRedirect";
 import { Text } from "./style";
 
 interface LoginAlertModalProps {
-  isVisible: boolean;
   onClose: () => void;
 }
 
-export default function LoginAlertModal({
-  isVisible,
-  onClose,
-}: LoginAlertModalProps) {
+export default function LoginAlertModal({ onClose }: LoginAlertModalProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const { setRedirect } = useRedirect();
@@ -29,7 +25,7 @@ export default function LoginAlertModal({
 
   return (
     <>
-      <Modal isVisible={isVisible} size="md" onClose={onClose}>
+      <Modal size="md" onClose={onClose}>
         <Modal.Content>
           <Text>로그인이 필요해요</Text>
         </Modal.Content>

--- a/src/features/bookmarks/components/BookmarkButton.tsx
+++ b/src/features/bookmarks/components/BookmarkButton.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence } from "framer-motion";
 import { useEffect, useState } from "react";
 
 import Button from "@/components/Button";
@@ -59,10 +60,12 @@ export default function BookmarkButton({ animeId }: BookmarkButtonProps) {
       >
         {isBookmarked ? "입덕한 애니" : "입덕하기"}
       </Button>
-      <LoginAlertModal
-        isVisible={isLoginModalVisible}
-        onClose={() => setIsLoginModalVisible(false)}
-      />
+
+      <AnimatePresence>
+        {isLoginModalVisible && (
+          <LoginAlertModal onClose={() => setIsLoginModalVisible(false)} />
+        )}
+      </AnimatePresence>
     </>
   );
 }

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from "@emotion/react";
 import { DotsThree } from "@phosphor-icons/react";
+import { AnimatePresence } from "framer-motion";
 import { useState } from "react";
 
 import Button from "@/components/Button";
@@ -13,7 +14,7 @@ import ShortReviewModal from "../ReviewRating/ShortReviewModal";
 
 import { MyRating, RatingContainer } from "./ReviewMoreButton.style";
 
-const USER_MOCK_DATA = { isMine: false };
+const USER_MOCK_DATA = { isMine: true };
 const USER_MOCK_REVIEW_DATA = {
   score: 7,
   content: "유저가 생성한 짧은 리뷰입니다.",
@@ -62,39 +63,43 @@ export default function ReviewMoreButton() {
         color="neutral"
         onClick={handleDropDownModalToggle}
       />
-      <DropDownModal
-        isVisible={isDropDownModalOpen}
-        onDropDownModalToggle={handleDropDownModalToggle}
-      >
-        <DropDownModal.Button
-          name={USER_MOCK_DATA.isMine ? "수정하기" : "스포일러 신고"}
-          size="lg"
-          variant="solid"
-          color="neutral"
-          onClick={() =>
-            USER_MOCK_DATA.isMine
-              ? handleReviewEditClick()
-              : handleReviewSpoilerReport()
-          }
-        >
-          {USER_MOCK_DATA.isMine ? "수정하기" : "스포일러 신고"}
-        </DropDownModal.Button>
-        <DropDownModal.Button
-          name={USER_MOCK_DATA.isMine ? "삭제하기" : "기타 신고"}
-          size="lg"
-          variant="solid"
-          color="neutral"
-          onClick={() =>
-            USER_MOCK_DATA.isMine
-              ? handleReviewDeleteClick()
-              : handleReviewEtcReport()
-          }
-        >
-          {USER_MOCK_DATA.isMine ? "삭제하기" : "기타 신고"}
-        </DropDownModal.Button>
-      </DropDownModal>
+      <AnimatePresence>
+        {isDropDownModalOpen && (
+          <DropDownModal
+            key="DropDownModal"
+            onDropDownModalToggle={handleDropDownModalToggle}
+          >
+            <DropDownModal.Button
+              name={USER_MOCK_DATA.isMine ? "수정하기" : "스포일러 신고"}
+              size="lg"
+              variant="solid"
+              color="neutral"
+              onClick={() =>
+                USER_MOCK_DATA.isMine
+                  ? handleReviewEditClick()
+                  : handleReviewSpoilerReport()
+              }
+            >
+              {USER_MOCK_DATA.isMine ? "수정하기" : "스포일러 신고"}
+            </DropDownModal.Button>
+            <DropDownModal.Button
+              name={USER_MOCK_DATA.isMine ? "삭제하기" : "기타 신고"}
+              size="lg"
+              variant="solid"
+              color="neutral"
+              onClick={() =>
+                USER_MOCK_DATA.isMine
+                  ? handleReviewDeleteClick()
+                  : handleReviewEtcReport()
+              }
+            >
+              {USER_MOCK_DATA.isMine ? "삭제하기" : "기타 신고"}
+            </DropDownModal.Button>
+          </DropDownModal>
+        )}
+      </AnimatePresence>
 
-      <ShortReviewModal
+      {/* <ShortReviewModal
         isVisible={isReviewModalVisible}
         onClose={() => setIsReviewModalVisible(false)}
         onReview={() => setIsReviewModalVisible(false)}
@@ -108,7 +113,7 @@ export default function ReviewMoreButton() {
             value={USER_MOCK_REVIEW_DATA.score}
           />
         </RatingContainer>
-      </ShortReviewModal>
+      </ShortReviewModal> */}
 
       <SnackBar ref={snackBarRef} text="신고가 접수되었습니다" />
     </>

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
@@ -97,23 +97,25 @@ export default function ReviewMoreButton() {
             </DropDownModal.Button>
           </DropDownModal>
         )}
-      </AnimatePresence>
 
-      {/* <ShortReviewModal
-        isVisible={isReviewModalVisible}
-        onClose={() => setIsReviewModalVisible(false)}
-        onReview={() => setIsReviewModalVisible(false)}
-        userReviewData={USER_MOCK_REVIEW_DATA}
-      >
-        <MyRating>내 별점</MyRating>
-        <RatingContainer>
-          <Rating
-            size="lg"
-            onRate={handleRate}
-            value={USER_MOCK_REVIEW_DATA.score}
-          />
-        </RatingContainer>
-      </ShortReviewModal> */}
+        {isReviewModalVisible && (
+          <ShortReviewModal
+            key="ShortReviewModal"
+            onClose={() => setIsReviewModalVisible(false)}
+            onReview={() => setIsReviewModalVisible(false)}
+            userReviewData={USER_MOCK_REVIEW_DATA}
+          >
+            <MyRating>내 별점</MyRating>
+            <RatingContainer>
+              <Rating
+                size="lg"
+                onRate={handleRate}
+                value={USER_MOCK_REVIEW_DATA.score}
+              />
+            </RatingContainer>
+          </ShortReviewModal>
+        )}
+      </AnimatePresence>
 
       <SnackBar ref={snackBarRef} text="신고가 접수되었습니다" />
     </>

--- a/src/features/reviews/components/ReviewRating/ShortReviewModal.tsx
+++ b/src/features/reviews/components/ReviewRating/ShortReviewModal.tsx
@@ -25,14 +25,12 @@ interface MOCK_USER_REVIEW_DATA {
 }
 
 interface ShortReviewModalProps {
-  isVisible: boolean;
   onClose: () => void;
   onReview: () => void;
   userReviewData?: MOCK_USER_REVIEW_DATA;
 }
 
 export default function ShortReviewModal({
-  isVisible,
   onClose,
   onReview,
   userReviewData,
@@ -126,7 +124,7 @@ export default function ShortReviewModal({
   // };
 
   return (
-    <Modal isVisible={isVisible} onClose={onClose}>
+    <Modal onClose={onClose}>
       <Modal.Content>
         <Title>한 줄 리뷰 모달</Title>
         {children}

--- a/src/features/reviews/components/ReviewRating/index.tsx
+++ b/src/features/reviews/components/ReviewRating/index.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence } from "framer-motion";
 import { useState } from "react";
 
 import Rating from "@/components/Rating";
@@ -42,15 +43,23 @@ export default function ReviewRating({ animeId }: ReviewRatingProps) {
         </ReviewRecommend>
       )}
       {hasReviewed && "TODO: 사용자 리뷰 렌더링 "}
-      <ShortReviewModal
-        isVisible={isReviewModalVisible}
-        onClose={() => setIsReviewModalVisible(false)}
-        onReview={() => setIsReviewModalVisible(false)}
-      />
-      <LoginAlertModal
-        isVisible={isLoginModalVisible}
-        onClose={() => setIsLoginModalVisible(false)}
-      />
+
+      <AnimatePresence>
+        {isReviewModalVisible && (
+          <ShortReviewModal
+            key="ShortReviewModal"
+            onClose={() => setIsReviewModalVisible(false)}
+            onReview={() => setIsReviewModalVisible(false)}
+          />
+        )}
+
+        {isLoginModalVisible && (
+          <LoginAlertModal
+            key="LoginAlertModal"
+            onClose={() => setIsLoginModalVisible(false)}
+          />
+        )}
+      </AnimatePresence>
     </>
   );
 }

--- a/src/features/users/components/DropDownModal/index.tsx
+++ b/src/features/users/components/DropDownModal/index.tsx
@@ -1,23 +1,21 @@
 import { Variants } from "framer-motion";
 
 import Button from "@/components/Button";
-import AnimatePortal from "@/components/Portal/AnimatePortal";
+import Portal from "@/components/Portal";
 import { StrictPropsWithChildren } from "@/types";
 
 import { ButtonContainer, Backdrop } from "./style";
 
 export interface DropDownModalProps {
-  isVisible: boolean;
   onDropDownModalToggle: () => void;
 }
 
 export default function DropDownModal({
-  isVisible,
   onDropDownModalToggle,
   children,
 }: StrictPropsWithChildren<DropDownModalProps>) {
   return (
-    <AnimatePortal isVisible={isVisible}>
+    <Portal>
       <Backdrop onClick={onDropDownModalToggle} />
       {/* 애니메이션 props: variants, animate, exit */}
       <ButtonContainer variants={variants} animate="animate" exit="exit">
@@ -32,7 +30,7 @@ export default function DropDownModal({
           취소
         </Button>
       </ButtonContainer>
-    </AnimatePortal>
+    </Portal>
   );
 }
 

--- a/src/features/users/components/DropDownModal/index.tsx
+++ b/src/features/users/components/DropDownModal/index.tsx
@@ -2,6 +2,7 @@ import { Variants } from "framer-motion";
 
 import Button from "@/components/Button";
 import Portal from "@/components/Portal";
+import useScrollLock from "@/hooks/useScrollLock";
 import { StrictPropsWithChildren } from "@/types";
 
 import { ButtonContainer, Backdrop } from "./style";
@@ -14,6 +15,8 @@ export default function DropDownModal({
   onDropDownModalToggle,
   children,
 }: StrictPropsWithChildren<DropDownModalProps>) {
+  useScrollLock(true);
+
   return (
     <Portal>
       <Backdrop onClick={onDropDownModalToggle} />

--- a/src/features/users/components/ProfileImageSection/ProfileReportModal.tsx
+++ b/src/features/users/components/ProfileImageSection/ProfileReportModal.tsx
@@ -18,28 +18,26 @@ const OPTION = [
 ];
 
 interface ProfileReportModalProps {
-  isVisible: boolean;
   onClose: () => void;
 }
 
 export default function ProfileReportModal({
-  isVisible,
   onClose,
 }: ProfileReportModalProps) {
   const { snackBarRef, showSnackBar } = useSnackBar();
-
   const [selected, setSelected] = useState(OPTION[0].value);
+
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) =>
     setSelected(e.target.value);
   const handleReportSumbit = () => {
     onClose();
     showSnackBar();
-    setSelected(OPTION[0].value);
   };
 
   return (
     <>
-      <Modal isVisible={isVisible} onClose={onClose}>
+      <Modal onClose={onClose}>
+        {/* <Modal isVisible={isVisible} onClose={onClose}> */}
         <Modal.Content>
           <Header>
             <Title>신고하기</Title>

--- a/src/features/users/components/ProfileImageSection/ProfileSetupButton.tsx
+++ b/src/features/users/components/ProfileImageSection/ProfileSetupButton.tsx
@@ -38,33 +38,40 @@ export default function ProfileSetupButton({
           <Dot />
         </Dots>
       </ProfileSetupButtonContainer>
-      <DropDownModal
-        isVisible={isDropDownModalOpen}
-        onDropDownModalToggle={handleDropDownModalToggle}
-      >
-        <DropDownModal.Button
-          name="프로필 링크 복사"
-          size="lg"
-          variant="solid"
-          color="neutral"
-        >
-          프로필 링크 복사
-        </DropDownModal.Button>
-        <DropDownModal.Button
-          name={isMine ? "프로필 수정" : "신고하기"}
-          size="lg"
-          variant="solid"
-          color="neutral"
-          onClick={() =>
-            isMine ? handleLinkToEditClick() : handleReportClick()
-          }
-        >
-          {isMine ? "프로필 수정" : "신고하기"}
-        </DropDownModal.Button>
-      </DropDownModal>
+
       <AnimatePresence>
+        {isDropDownModalOpen && (
+          <DropDownModal
+            key="DropDownModal"
+            onDropDownModalToggle={handleDropDownModalToggle}
+          >
+            <DropDownModal.Button
+              name="프로필 링크 복사"
+              size="lg"
+              variant="solid"
+              color="neutral"
+            >
+              프로필 링크 복사
+            </DropDownModal.Button>
+            <DropDownModal.Button
+              name={isMine ? "프로필 수정" : "신고하기"}
+              size="lg"
+              variant="solid"
+              color="neutral"
+              onClick={() =>
+                isMine ? handleLinkToEditClick() : handleReportClick()
+              }
+            >
+              {isMine ? "프로필 수정" : "신고하기"}
+            </DropDownModal.Button>
+          </DropDownModal>
+        )}
+
         {isReportModalOpen && (
-          <ProfileReportModal onClose={handleReportModalToggle} />
+          <ProfileReportModal
+            key="ProfileReportModal"
+            onClose={handleReportModalToggle}
+          />
         )}
       </AnimatePresence>
     </>

--- a/src/features/users/components/ProfileImageSection/ProfileSetupButton.tsx
+++ b/src/features/users/components/ProfileImageSection/ProfileSetupButton.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence } from "framer-motion";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -61,10 +62,11 @@ export default function ProfileSetupButton({
           {isMine ? "프로필 수정" : "신고하기"}
         </DropDownModal.Button>
       </DropDownModal>
-      <ProfileReportModal
-        isVisible={isReportModalOpen}
-        onClose={handleReportModalToggle}
-      />
+      <AnimatePresence>
+        {isReportModalOpen && (
+          <ProfileReportModal onClose={handleReportModalToggle} />
+        )}
+      </AnimatePresence>
     </>
   );
 }

--- a/src/features/users/routes/Profile/AboutMe/StatModal.tsx
+++ b/src/features/users/routes/Profile/AboutMe/StatModal.tsx
@@ -11,18 +11,13 @@ interface StatItemProps {
 }
 
 interface StatModalProps {
-  isVisible: boolean;
   items: StatItemProps[];
   onClose: () => void;
 }
 
-export default function StatModal({
-  isVisible,
-  items,
-  onClose,
-}: StatModalProps) {
+export default function StatModal({ items, onClose }: StatModalProps) {
   return (
-    <Modal isVisible={isVisible} onClose={onClose}>
+    <Modal onClose={onClose}>
       <Modal.Content>
         <ContentContainer>
           {items.map((item, index) => (

--- a/src/features/users/routes/Profile/AboutMe/index.tsx
+++ b/src/features/users/routes/Profile/AboutMe/index.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence } from "framer-motion";
 import { useState } from "react";
 
 import Stat from "@/components/Stat";
@@ -53,11 +54,11 @@ export default function AboutMe() {
       <StatContainer onClick={handleStatModalToggle}>
         <Stat variant="ghost" items={STAT_MOCK_DATA} />
       </StatContainer>
-      <StatModal
-        isVisible={isStatModalVisible}
-        onClose={handleStatModalToggle}
-        items={STAT_MOCK_DATA}
-      />
+      <AnimatePresence>
+        {isStatModalVisible && (
+          <StatModal onClose={handleStatModalToggle} items={STAT_MOCK_DATA} />
+        )}
+      </AnimatePresence>
     </>
   );
 }


### PR DESCRIPTION
## 📝 개요
모달 컴포넌트의 state가 유지되지 않도록 수정했습니다.
BottomSheet는 state가 유지될 수 있도록 수정하지 않았습니다.

## 🚀 변경사항
- 기존 `Modal` 컴포넌트
```tsx
  return (
    <AnimatePortal isVisible={isVisible}>
      <Backdrop isVisible={showBackdrop} onClick={onClose} />
      <ModalContainer
        aria-modal={isVisible}
        role="dialog"
        initial="initial"
        animate="animate"
        exit="exit"
        variants={modalVariants}
        size={size}
        onClick={(e) => e.stopPropagation()}
      >
        {children}
      </ModalContainer>
    </AnimatePortal>
  );
```

- 변경된 `Modal` 컴포넌트
```tsx


  return (
    <Portal>
      <Backdrop isVisible={showBackdrop} onClick={onClose} />
      <ModalContainer
        aria-modal={isVisible}
        role="dialog"
        initial="initial"
        animate="animate"
        exit="exit"
        variants={modalVariants}
        size={size}
        onClick={(e) => e.stopPropagation()}
      >
        {children}
      </ModalContainer>
    </Portal>
  );
}
```

------------------

- 기존 Modal 사용법
```tsx
      <StatModal
        isVisible={isStatModalVisible}
        onClose={handleStatModalToggle}
        items={STAT_MOCK_DATA}
      />
```

- 변경된 Modal 사용법
```tsx
      <AnimatePresence>
        {isStatModalVisible && (
          <StatModal onClose={handleStatModalToggle} items={STAT_MOCK_DATA} />
        )}
      </AnimatePresence>
```
1. `AnimatePresence` 컴포넌트로 모달 컴포넌트 감싸기
2. `isVisible`을 props으로 넘기지 않고 `isVisible`이 true 일때만 모달이 렌더링 될 수 있도록 합니다.


## 🔗 관련 이슈

#195


## ➕ 기타

- 변경된 코드에서 SnackBar 컴포넌트 애니메이션이 제대로 동작하지 않아 변경 예정입니다.
- [framer - AnimatePresence 공식문서](https://www.framer.com/motion/animate-presence/)

