### PR TITLE
feat: snack bar 로직 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^1.3.0",
-        "react-router-dom": "^6.14.2"
+        "react-router-dom": "^6.14.2",
+        "uuidv4": "^6.2.13"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.3",
@@ -2815,6 +2816,11 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.2.0",
@@ -6635,9 +6641,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -7788,6 +7794,15 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^1.3.0",
-    "react-router-dom": "^6.14.2"
+    "react-router-dom": "^6.14.2",
+    "uuidv4": "^6.2.13"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { RouterProvider } from "react-router-dom";
 import DeferredComponent from "./components/DeferredComponent";
 import Loader from "./components/Loader";
 import { AuthProvider } from "./contexts/AuthContext";
+import { SnackBarContextProvider } from "./contexts/SnackBarContext";
 import router from "./routes";
 import { theme } from "./styles/theme";
 
@@ -19,24 +20,26 @@ export default function App() {
             size: 24,
           }}
         >
-          <Global
-            styles={css`
-              body {
-                color: ${theme.colors.neutral["90"]};
-              }
-            `}
-          />
-          <AuthProvider>
-            <Suspense
-              fallback={
-                <DeferredComponent>
-                  <Loader />
-                </DeferredComponent>
-              }
-            >
-              <RouterProvider router={router} />
-            </Suspense>
-          </AuthProvider>
+          <SnackBarContextProvider option={{ position: "bottom" }}>
+            <Global
+              styles={css`
+                body {
+                  color: ${theme.colors.neutral["90"]};
+                }
+              `}
+            />
+            <AuthProvider>
+              <Suspense
+                fallback={
+                  <DeferredComponent>
+                    <Loader />
+                  </DeferredComponent>
+                }
+              >
+                <RouterProvider router={router} />
+              </Suspense>
+            </AuthProvider>
+          </SnackBarContextProvider>
         </IconContext.Provider>
       </ThemeProvider>
     </HelmetProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ export default function App() {
             size: 24,
           }}
         >
-          <SnackBarContextProvider option={{ position: "bottom" }}>
+          <SnackBarContextProvider>
             <Global
               styles={css`
                 body {

--- a/src/components/SnackBar/SnackBarPortal.tsx
+++ b/src/components/SnackBar/SnackBarPortal.tsx
@@ -34,12 +34,11 @@ export default function SnackBarPortal({
       : theme.zIndex.modal.toString();
     div.id = portalId;
     div.style.position = "fixed";
-    div.style.backgroundColor = "#DFEVDV";
     div.style.left = "50%";
     div.style.transform = "translateX(-50%)";
 
     if (position === "top") {
-      div.style.top = "74px";
+      div.style.top = "16px";
     }
 
     if (position === "bottom") {
@@ -65,6 +64,7 @@ export default function SnackBarPortal({
       {orderByCreatedAt.map((snackBarLocalOptions) => (
         <SnackBar
           key={snackBarLocalOptions.id}
+          position={position}
           onClose={onCloseSnackBar}
           {...snackBarGlobalOptions}
           {...snackBarLocalOptions}

--- a/src/components/SnackBar/SnackBarPortal.tsx
+++ b/src/components/SnackBar/SnackBarPortal.tsx
@@ -13,14 +13,13 @@ export interface SnackBarPortalProps extends SnackbarPublicProps {
   onCloseSnackBar?: (id: string) => void;
   zIndex?: string | number;
   snackBars?: SnackBarItem[];
-  position?: "top" | "bottom";
 }
 
 export default function SnackBarPortal({
   portalId = "snackBar-portal",
   onCloseSnackBar,
   zIndex,
-  position,
+  position = "bottom",
   snackBars = [],
   ...snackBarGlobalOptions
 }: SnackBarPortalProps) {

--- a/src/components/SnackBar/SnackBarPortal.tsx
+++ b/src/components/SnackBar/SnackBarPortal.tsx
@@ -9,7 +9,7 @@ import SnackBar, { SnackbarPublicProps } from ".";
 
 export interface SnackBarPortalProps extends SnackbarPublicProps {
   portalId?: PortalID;
-  off?: (id: string) => void;
+  onCloseSnackBar?: (id: string) => void;
   zIndex?: string | number;
   snackBars?: SnackBarItem[];
   position?: "top" | "bottom";
@@ -17,7 +17,7 @@ export interface SnackBarPortalProps extends SnackbarPublicProps {
 
 export default function SnackBarPortal({
   portalId = "snackBar-portal",
-  off,
+  onCloseSnackBar,
   zIndex,
   position,
   snackBars = [],
@@ -65,7 +65,7 @@ export default function SnackBarPortal({
       {orderByCreatedAt.map((snackBarLocalOptions) => (
         <SnackBar
           key={snackBarLocalOptions.id}
-          onClose={off}
+          onClose={onCloseSnackBar}
           {...snackBarGlobalOptions}
           {...snackBarLocalOptions}
         />

--- a/src/components/SnackBar/SnackBarPortal.tsx
+++ b/src/components/SnackBar/SnackBarPortal.tsx
@@ -1,0 +1,76 @@
+import { useTheme } from "@emotion/react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { SnackBar as SnackBarItem } from "@/contexts/SnackBarContainerReducer";
+import { PortalID } from "@/contexts/SnackBarContext";
+
+import SnackBar, { SnackbarPublicProps } from ".";
+
+export interface SnackBarPortalProps extends SnackbarPublicProps {
+  portalId?: PortalID;
+  off?: (id: string) => void;
+  zIndex?: string | number;
+  snackBars?: SnackBarItem[];
+  position?: "top" | "bottom";
+}
+
+export default function SnackBarPortal({
+  portalId = "snackBar-portal",
+  off,
+  zIndex,
+  position,
+  snackBars = [],
+  ...snackBarGlobalOptions
+}: SnackBarPortalProps) {
+  const [loaded, setLoaded] = useState(false);
+  const theme = useTheme();
+
+  useEffect(() => {
+    const div = document.createElement("div");
+    div.setAttribute("role", "log");
+    div.style.zIndex = zIndex
+      ? zIndex.toString()
+      : theme.zIndex.modal.toString();
+    div.id = portalId;
+    div.style.position = "fixed";
+    div.style.backgroundColor = "#DFEVDV";
+    div.style.left = "50%";
+    div.style.transform = "translateX(-50%)";
+
+    if (position === "top") {
+      div.style.top = "74px";
+    }
+
+    if (position === "bottom") {
+      div.style.bottom = "74px";
+    }
+    document.getElementsByTagName("body")[0].prepend(div);
+
+    setLoaded(true);
+
+    return () => {
+      document.getElementsByTagName("body")[0].removeChild(div);
+    };
+  }, [portalId, position, theme.zIndex.modal, zIndex]);
+
+  if (!(loaded && snackBars && snackBars.length > 0)) {
+    return null;
+  }
+
+  const orderByCreatedAt = snackBars.reverse();
+
+  return createPortal(
+    <>
+      {orderByCreatedAt.map((snackBarLocalOptions) => (
+        <SnackBar
+          key={snackBarLocalOptions.id}
+          onClose={off}
+          {...snackBarGlobalOptions}
+          {...snackBarLocalOptions}
+        />
+      ))}
+    </>,
+    document.getElementById(portalId) as HTMLElement,
+  );
+}

--- a/src/components/SnackBar/SnackBarPortal.tsx
+++ b/src/components/SnackBar/SnackBarPortal.tsx
@@ -2,8 +2,9 @@ import { useTheme } from "@emotion/react";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
-import { SnackBar as SnackBarItem } from "@/contexts/SnackBarContainerReducer";
 import { PortalID } from "@/contexts/SnackBarContext";
+
+import { SnackBar as SnackBarItem } from "./snackBarReducer";
 
 import SnackBar, { SnackbarPublicProps } from ".";
 

--- a/src/components/SnackBar/SnackBarPortal.tsx
+++ b/src/components/SnackBar/SnackBarPortal.tsx
@@ -26,6 +26,7 @@ export default function SnackBarPortal({
   const [loaded, setLoaded] = useState(false);
   const theme = useTheme();
 
+  // <div id="snackBar-portal" /> 생성
   useEffect(() => {
     const div = document.createElement("div");
     div.setAttribute("role", "log");

--- a/src/components/SnackBar/index.tsx
+++ b/src/components/SnackBar/index.tsx
@@ -19,7 +19,7 @@ export interface SnackBarProps extends SnackbarPublicProps {
 export default function SnackBar({
   id,
   message,
-  duration = 10,
+  duration = 2,
   position = "bottom",
   onClose,
 }: SnackBarProps) {

--- a/src/components/SnackBar/index.tsx
+++ b/src/components/SnackBar/index.tsx
@@ -3,10 +3,11 @@ import { useMemo, useState } from "react";
 import { SnackBarContainer } from "./style";
 import useInterval from "./useInterval";
 
+export type Position = "top" | "bottom";
 export interface SnackbarPublicProps {
   /**snackBar 지속시간 */
   duration?: number;
-  position?: "top" | "bottom";
+  position?: Position;
 }
 
 export interface SnackBarProps extends SnackbarPublicProps {
@@ -18,7 +19,7 @@ export interface SnackBarProps extends SnackbarPublicProps {
 export default function SnackBar({
   id,
   message,
-  duration = 2,
+  duration = 10,
   position = "bottom",
   onClose,
 }: SnackBarProps) {
@@ -29,6 +30,7 @@ export default function SnackBar({
     () => (remainSeconds >= 0 ? 100 : null),
     [remainSeconds],
   );
+
   useInterval(() => {
     setRemainSeconds(remainSeconds - 100);
     if (remainSeconds === 0) {
@@ -37,6 +39,8 @@ export default function SnackBar({
   }, interval);
 
   return (
-    <SnackBarContainer onClick={onCloseSnackbar}>{message}</SnackBarContainer>
+    <SnackBarContainer onClick={onCloseSnackbar} position={position}>
+      {message}
+    </SnackBarContainer>
   );
 }

--- a/src/components/SnackBar/index.tsx
+++ b/src/components/SnackBar/index.tsx
@@ -1,23 +1,43 @@
-import { forwardRef } from "react";
+import { useMemo, useState } from "react";
 
 import { SnackBarContainer } from "./style";
+import useInterval from "./useInterval";
 
-interface SnackBarProps {
-  text: string;
+export interface SnackbarPublicProps {
+  /**
+   * 0: infinity
+   * 1 ~ : for the given time, snackbar appears and disappears
+   * */
+  duration?: number;
 }
 
-//TODO: SnackBar animation 변경
-const SnackBar = forwardRef(
-  ({ text }: SnackBarProps, ref: React.ForwardedRef<HTMLDivElement>) => {
-    // const [isPresent, safeToRemove] = usePresence();
-    // useEffect(() => {
-    //   !isPresent && setTimeout(safeToRemove, 2000);
-    // }, [isPresent, safeToRemove]);
+export interface SnackBarProps extends SnackbarPublicProps {
+  id: string;
+  message: string;
+  onClose?: (id: string) => void;
+}
 
-    return <SnackBarContainer ref={ref}>{text}</SnackBarContainer>;
-  },
-);
+export default function SnackBar({
+  id,
+  message,
+  duration = 2,
+  onClose,
+}: SnackBarProps) {
+  const [remainSeconds, setRemainSeconds] = useState<number>(duration * 1000);
+  const onCloseSnackbar = () => onClose?.(id);
 
-SnackBar.displayName = "SnackBar";
+  const interval = useMemo(
+    () => (remainSeconds >= 0 ? 100 : null),
+    [remainSeconds],
+  );
+  useInterval(() => {
+    setRemainSeconds(remainSeconds - 100);
+    if (remainSeconds === 0) {
+      onCloseSnackbar();
+    }
+  }, interval);
 
-export default SnackBar;
+  return (
+    <SnackBarContainer onClick={onCloseSnackbar}>{message}</SnackBarContainer>
+  );
+}

--- a/src/components/SnackBar/index.tsx
+++ b/src/components/SnackBar/index.tsx
@@ -4,11 +4,9 @@ import { SnackBarContainer } from "./style";
 import useInterval from "./useInterval";
 
 export interface SnackbarPublicProps {
-  /**
-   * 0: infinity
-   * 1 ~ : for the given time, snackbar appears and disappears
-   * */
+  /**snackBar 지속시간 */
   duration?: number;
+  position?: "top" | "bottom";
 }
 
 export interface SnackBarProps extends SnackbarPublicProps {
@@ -21,6 +19,7 @@ export default function SnackBar({
   id,
   message,
   duration = 2,
+  position = "bottom",
   onClose,
 }: SnackBarProps) {
   const [remainSeconds, setRemainSeconds] = useState<number>(duration * 1000);

--- a/src/components/SnackBar/snackBarReducer.ts
+++ b/src/components/SnackBar/snackBarReducer.ts
@@ -16,10 +16,7 @@ export type Action =
 
 export const initialState: SnackBar[] = [];
 
-export function snackBarContainerReducer(
-  state: SnackBar[],
-  action: Action,
-): SnackBar[] {
+export function snackBarReducer(state: SnackBar[], action: Action): SnackBar[] {
   switch (action.type) {
     case ActionType.ADD:
       return [...state, action.payload.options];

--- a/src/components/SnackBar/style.ts
+++ b/src/components/SnackBar/style.ts
@@ -4,13 +4,7 @@ export const SnackBarContainer = styled.div`
   --side-padding: 32px; // 16 * 2
   width: calc(100vw - var(--side-padding));
   max-width: calc(600px - var(--side-padding));
-  opacity: 0;
-  visibility: hidden;
   height: 40px;
-  position: fixed;
-  left: 50%;
-  bottom: 74px; // 66 + 8
-  transform: translateX(-50%);
   background-color: ${({ theme }) => theme.colors.neutral[90]};
   color: ${({ theme }) => theme.colors.neutral["05"]};
   ${({ theme }) => theme.typo["body-2-m"]}

--- a/src/components/SnackBar/style.ts
+++ b/src/components/SnackBar/style.ts
@@ -17,6 +17,7 @@ export const SnackBarContainer = styled.div<Pick<SnackBarProps, "position">>`
   border-radius: 8px;
   z-index: ${({ theme }) => theme.zIndex.modal};
   margin-bottom: 4px;
+  cursor: pointer;
 
   ${({ position = "bottom" }) => css`
     animation: ${getAnimation(position)} 0.3s;

--- a/src/components/SnackBar/style.ts
+++ b/src/components/SnackBar/style.ts
@@ -1,6 +1,9 @@
+import { css, keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
 
-export const SnackBarContainer = styled.div`
+import { Position, SnackBarProps } from ".";
+
+export const SnackBarContainer = styled.div<Pick<SnackBarProps, "position">>`
   --side-padding: 32px; // 16 * 2
   width: calc(100vw - var(--side-padding));
   max-width: calc(600px - var(--side-padding));
@@ -13,4 +16,24 @@ export const SnackBarContainer = styled.div`
   align-items: center;
   border-radius: 8px;
   z-index: ${({ theme }) => theme.zIndex.modal};
+  margin-bottom: 4px;
+
+  ${({ position = "bottom" }) => css`
+    animation: ${getAnimation(position)} 0.3s;
+  `}
+`;
+
+function getAnimation(position: Position) {
+  if (position === "top") return fadeinTopToBottom;
+  if (position === "bottom") return fadeinBottomToTop;
+}
+
+const fadeinTopToBottom = keyframes`
+  from { transform: translateY(-100%); opacity: 0 }
+  to { transform: translateY(0); opacity: 1 }
+`;
+
+const fadeinBottomToTop = keyframes`
+  from { transform: translateY(100%); opacity: 0 }
+  to { transform: translateY(0); opacity: 1 }
 `;

--- a/src/components/SnackBar/useInterval.ts
+++ b/src/components/SnackBar/useInterval.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from "react";
+
+export default function useInterval(
+  callback: () => void,
+  delay: number | null,
+) {
+  const savedCallback = useRef(callback);
+
+  // Remember the latest callback if it changes.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    // Don't schedule if no delay is specified.
+    if (delay === null) {
+      return;
+    }
+
+    const id = setInterval(() => savedCallback.current(), delay);
+
+    return () => clearInterval(id);
+  }, [delay]);
+}

--- a/src/components/SnackBar/useSnackBar.tsx
+++ b/src/components/SnackBar/useSnackBar.tsx
@@ -1,43 +1,29 @@
-import { useRef } from "react";
+import { useContext } from "react";
+import { v4 as uuidv4 } from "uuid";
 
-type Position = "bottom" | "top";
+import { ActionType } from "@/contexts/SnackBarContainerReducer";
+import { SnackBarContext } from "@/contexts/SnackBarContext";
+
+import { SnackBarProps } from ".";
 
 export default function useSnackBar() {
-  const snackBarRef = useRef<HTMLDivElement>(null);
-  const showSnackBar = (position: Position = "bottom") =>
-    snackBarRef.current?.animate(keyframes(position), options);
+  const context = useContext(SnackBarContext);
 
+  if (!context) return null;
   return {
-    snackBarRef,
-    showSnackBar,
+    on: (options: Omit<SnackBarProps, "id" | "position">) => {
+      context.dispatch({
+        type: ActionType.ADD,
+        payload: { options: { ...options, id: uuidv4() } },
+      });
+    },
+    off: (id: string) => {
+      context.dispatch({
+        type: ActionType.REMOVE,
+        payload: { id },
+      });
+    },
+    length: context.snackBars.length,
+    list: context.snackBars,
   };
 }
-
-const keyframes = (position: Position) => [
-  {
-    [position]: `${position === "bottom" ? "66px" : "16px"}`,
-    opacity: 0,
-    visibility: "visible",
-    offset: 0,
-  },
-  {
-    [position]: `${position === "bottom" ? "74px" : "24px"}`,
-    opacity: 1,
-    offset: 0.2,
-  },
-  {
-    [position]: `${position === "bottom" ? "74px" : "24px"}`,
-    opacity: 1,
-    offset: 0.8,
-  },
-  {
-    [position]: `${position === "bottom" ? "66px" : "16px"}`,
-    opacity: 0,
-    offset: 1,
-  },
-];
-
-const options = {
-  duration: 2000,
-  easing: "linear",
-};

--- a/src/components/SnackBar/useSnackBar.tsx
+++ b/src/components/SnackBar/useSnackBar.tsx
@@ -9,16 +9,19 @@ import { SnackBarProps } from ".";
 /**
  * @example
  * const snackBar = useSnackBar();
- * snackBar?.open({ message: "신고가 접수되었습니다." });
+ * snackBar.open({ message: "신고가 접수되었습니다." });
  */
 export default function useSnackBar() {
   const context = useContext(SnackBarContext);
 
-  if (!context) return null;
+  if (!context)
+    throw new Error(
+      "useSnackBar must be used within a SnackBarContextProvider",
+    );
   return {
     /**
      * @desc duration을 재정의 할 수 있습니다.
-     * @example snackBar?.open({ message: "신고가 접수되었습니다.", duration: 10 });
+     * @example snackBar.open({ message: "신고가 접수되었습니다.", duration: 10 });
      */
     open: (options: Omit<SnackBarProps, "id" | "position">) => {
       context.dispatch({

--- a/src/components/SnackBar/useSnackBar.tsx
+++ b/src/components/SnackBar/useSnackBar.tsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { v4 as uuidv4 } from "uuid";
 
-import { ActionType } from "@/contexts/SnackBarContainerReducer";
+import { ActionType } from "@/components/SnackBar/snackBarReducer";
 import { SnackBarContext } from "@/contexts/SnackBarContext";
 
 import { SnackBarProps } from ".";
@@ -11,13 +11,13 @@ export default function useSnackBar() {
 
   if (!context) return null;
   return {
-    on: (options: Omit<SnackBarProps, "id" | "position">) => {
+    open: (options: Omit<SnackBarProps, "id" | "position">) => {
       context.dispatch({
         type: ActionType.ADD,
         payload: { options: { ...options, id: uuidv4() } },
       });
     },
-    off: (id: string) => {
+    close: (id: string) => {
       context.dispatch({
         type: ActionType.REMOVE,
         payload: { id },

--- a/src/components/SnackBar/useSnackBar.tsx
+++ b/src/components/SnackBar/useSnackBar.tsx
@@ -6,11 +6,20 @@ import { SnackBarContext } from "@/contexts/SnackBarContext";
 
 import { SnackBarProps } from ".";
 
+/**
+ * @example
+ * const snackBar = useSnackBar();
+ * snackBar?.open({ message: "신고가 접수되었습니다." });
+ */
 export default function useSnackBar() {
   const context = useContext(SnackBarContext);
 
   if (!context) return null;
   return {
+    /**
+     * @desc duration을 재정의 할 수 있습니다.
+     * @example snackBar?.open({ message: "신고가 접수되었습니다.", duration: 10 });
+     */
     open: (options: Omit<SnackBarProps, "id" | "position">) => {
       context.dispatch({
         type: ActionType.ADD,

--- a/src/contexts/SnackBarContainerReducer.ts
+++ b/src/contexts/SnackBarContainerReducer.ts
@@ -1,0 +1,31 @@
+type SnackBarItemID = string;
+
+export interface SnackBar {
+  id: SnackBarItemID;
+  message: string;
+}
+
+export const enum ActionType {
+  ADD,
+  REMOVE,
+}
+
+export type Action =
+  | { type: ActionType.ADD; payload: { options: SnackBar } }
+  | { type: ActionType.REMOVE; payload: { id: SnackBarItemID } };
+
+export const initialState: SnackBar[] = [];
+
+export function snackBarContainerReducer(
+  state: SnackBar[],
+  action: Action,
+): SnackBar[] {
+  switch (action.type) {
+    case ActionType.ADD:
+      return [...state, action.payload.options];
+    case ActionType.REMOVE:
+      return state.filter((snackBar) => snackBar.id !== action.payload.id);
+    default:
+      return state;
+  }
+}

--- a/src/contexts/SnackBarContext.tsx
+++ b/src/contexts/SnackBarContext.tsx
@@ -21,7 +21,7 @@ interface State {
   id?: PortalID;
   /** snackBar list */
   snackBars: SnackBar[];
-  /** snackBar on, off 디스패치 */
+  /** snackBar 추가, 제거 디스패치 */
   dispatch: SnackBarDispatch;
 }
 
@@ -34,6 +34,12 @@ interface SnackBarContextProviderProps {
 
 export const SnackBarContext = createContext<State | null>(null);
 
+/**
+ * @desc: position default: "bottom"
+ * @desc: duration default: 2
+ * @desc: option을 재정의 할 수 있습니다.
+ * @example option={{ position: "top", duration: 10, zIndex: 9999 }}
+ */
 export function SnackBarContextProvider({
   id,
   option,

--- a/src/contexts/SnackBarContext.tsx
+++ b/src/contexts/SnackBarContext.tsx
@@ -43,7 +43,7 @@ export function SnackBarContextProvider({
     initialState,
   );
 
-  const off = (id: string) =>
+  const handleCloseSnackBar = (id: string) =>
     dispatch({ type: ActionType.REMOVE, payload: { id } });
 
   return (
@@ -52,7 +52,7 @@ export function SnackBarContextProvider({
       <SnackBarPortal
         portalId={id}
         snackBars={snackBars}
-        off={off}
+        onCloseSnackBar={handleCloseSnackBar}
         {...option}
       />
     </SnackBarContext.Provider>

--- a/src/contexts/SnackBarContext.tsx
+++ b/src/contexts/SnackBarContext.tsx
@@ -1,0 +1,60 @@
+import { Dispatch, createContext, useReducer } from "react";
+
+import SnackBarPortal, {
+  SnackBarPortalProps,
+} from "@/components/SnackBar/SnackBarPortal";
+import { StrictPropsWithChildren } from "@/types";
+
+import {
+  Action,
+  ActionType,
+  SnackBar,
+  initialState,
+  snackBarContainerReducer,
+} from "./SnackBarContainerReducer";
+
+type SnackBarDispatch = Dispatch<Action>;
+
+export type PortalID = string;
+interface State {
+  /** snackBar portal unique id */
+  id?: PortalID;
+  /** snackBar list */
+  snackBars: SnackBar[];
+  /** snackBar on, off 디스패치 */
+  dispatch: SnackBarDispatch;
+}
+
+interface SnackBarContextProviderProps {
+  /** snackBar portal unique id */
+  id?: PortalID;
+  option?: Omit<SnackBarPortalProps, "snackBars">;
+}
+
+export const SnackBarContext = createContext<State | null>(null);
+
+export function SnackBarContextProvider({
+  id,
+  option,
+  children,
+}: StrictPropsWithChildren<SnackBarContextProviderProps>) {
+  const [snackBars, dispatch] = useReducer(
+    snackBarContainerReducer,
+    initialState,
+  );
+
+  const off = (id: string) =>
+    dispatch({ type: ActionType.REMOVE, payload: { id } });
+
+  return (
+    <SnackBarContext.Provider value={{ id, snackBars, dispatch }}>
+      {children}
+      <SnackBarPortal
+        portalId={id}
+        snackBars={snackBars}
+        off={off}
+        {...option}
+      />
+    </SnackBarContext.Provider>
+  );
+}

--- a/src/contexts/SnackBarContext.tsx
+++ b/src/contexts/SnackBarContext.tsx
@@ -10,8 +10,8 @@ import {
   ActionType,
   SnackBar,
   initialState,
-  snackBarContainerReducer,
-} from "./SnackBarContainerReducer";
+  snackBarReducer,
+} from "../components/SnackBar/snackBarReducer";
 
 type SnackBarDispatch = Dispatch<Action>;
 
@@ -28,6 +28,7 @@ interface State {
 interface SnackBarContextProviderProps {
   /** snackBar portal unique id */
   id?: PortalID;
+  /** portal option */
   option?: Omit<SnackBarPortalProps, "snackBars">;
 }
 
@@ -38,10 +39,7 @@ export function SnackBarContextProvider({
   option,
   children,
 }: StrictPropsWithChildren<SnackBarContextProviderProps>) {
-  const [snackBars, dispatch] = useReducer(
-    snackBarContainerReducer,
-    initialState,
-  );
+  const [snackBars, dispatch] = useReducer(snackBarReducer, initialState);
 
   const handleCloseSnackBar = (id: string) =>
     dispatch({ type: ActionType.REMOVE, payload: { id } });

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
@@ -45,11 +45,11 @@ export default function ReviewMoreButton() {
   const handleReviewDeleteClick = () => console.log("리뷰삭제");
   const handleReviewSpoilerReport = () => {
     handleDropDownModalToggle();
-    snackBar?.open({ message: "신고가 접수되었습니다." });
+    snackBar.open({ message: "신고가 접수되었습니다." });
   };
   const handleReviewEtcReport = () => {
     handleDropDownModalToggle();
-    snackBar?.open({
+    snackBar.open({
       message: "신고가 접수되었습니다.",
     });
   };

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
@@ -117,8 +117,6 @@ export default function ReviewMoreButton() {
           </ShortReviewModal>
         )}
       </AnimatePresence>
-
-      {/* <SnackBar ref={snackBarRef} text="신고가 접수되었습니다" /> */}
     </>
   );
 }

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
@@ -5,7 +5,6 @@ import { useState } from "react";
 
 import Button from "@/components/Button";
 import Rating from "@/components/Rating";
-import SnackBar from "@/components/SnackBar";
 import useSnackBar from "@/components/SnackBar/useSnackBar";
 import DropDownModal from "@/features/users/components/DropDownModal";
 import useDropDownModal from "@/features/users/components/DropDownModal/useDropDownModal";
@@ -14,7 +13,7 @@ import ShortReviewModal from "../ReviewRating/ShortReviewModal";
 
 import { MyRating, RatingContainer } from "./ReviewMoreButton.style";
 
-const USER_MOCK_DATA = { isMine: true };
+const USER_MOCK_DATA = { isMine: false };
 const USER_MOCK_REVIEW_DATA = {
   score: 7,
   content: "유저가 생성한 짧은 리뷰입니다.",
@@ -29,7 +28,7 @@ const USER_MOCK_REVIEW_DATA = {
 export default function ReviewMoreButton() {
   const theme = useTheme();
   const { isDropDownModalOpen, handleDropDownModalToggle } = useDropDownModal();
-  const { snackBarRef, showSnackBar } = useSnackBar();
+  const snackBar = useSnackBar();
   const [isReviewModalVisible, setIsReviewModalVisible] = useState(false);
   const handleReviewEditClick = () => {
     handleDropDownModalToggle();
@@ -46,11 +45,13 @@ export default function ReviewMoreButton() {
   const handleReviewDeleteClick = () => console.log("리뷰삭제");
   const handleReviewSpoilerReport = () => {
     handleDropDownModalToggle();
-    showSnackBar();
+    snackBar?.open({ message: "신고가 접수되었습니다." });
   };
   const handleReviewEtcReport = () => {
     handleDropDownModalToggle();
-    showSnackBar();
+    snackBar?.open({
+      message: "신고가 접수되었습니다.",
+    });
   };
 
   return (
@@ -117,7 +118,7 @@ export default function ReviewMoreButton() {
         )}
       </AnimatePresence>
 
-      <SnackBar ref={snackBarRef} text="신고가 접수되었습니다" />
+      {/* <SnackBar ref={snackBarRef} text="신고가 접수되었습니다" /> */}
     </>
   );
 }

--- a/src/features/users/components/ProfileImageSection/ProfileReportModal.tsx
+++ b/src/features/users/components/ProfileImageSection/ProfileReportModal.tsx
@@ -30,7 +30,7 @@ export default function ProfileReportModal({
     setSelected(e.target.value);
   const handleReportSumbit = () => {
     onClose();
-    snackBar?.on({ message: "신고가 접수되었습니다." });
+    snackBar?.open({ message: "신고가 접수되었습니다." });
   };
 
   return (

--- a/src/features/users/components/ProfileImageSection/ProfileReportModal.tsx
+++ b/src/features/users/components/ProfileImageSection/ProfileReportModal.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import Button from "@/components/Button";
 import Modal from "@/components/Modal";
 import SelectBox from "@/components/SelectBox";
-import SnackBar from "@/components/SnackBar";
 import useSnackBar from "@/components/SnackBar/useSnackBar";
 
 import { CloseButton, Header, Title } from "./ProfileReportModal.style";
@@ -24,20 +23,19 @@ interface ProfileReportModalProps {
 export default function ProfileReportModal({
   onClose,
 }: ProfileReportModalProps) {
-  const { snackBarRef, showSnackBar } = useSnackBar();
+  const snackBar = useSnackBar();
   const [selected, setSelected] = useState(OPTION[0].value);
 
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) =>
     setSelected(e.target.value);
   const handleReportSumbit = () => {
     onClose();
-    showSnackBar();
+    snackBar?.on({ message: "신고가 접수되었습니다." });
   };
 
   return (
     <>
       <Modal onClose={onClose}>
-        {/* <Modal isVisible={isVisible} onClose={onClose}> */}
         <Modal.Content>
           <Header>
             <Title>신고하기</Title>
@@ -72,7 +70,6 @@ export default function ProfileReportModal({
           </Button>
         </Modal.Actions>
       </Modal>
-      <SnackBar ref={snackBarRef} text="신고가 접수되었습니다" />
     </>
   );
 }

--- a/src/features/users/components/ProfileImageSection/ProfileReportModal.tsx
+++ b/src/features/users/components/ProfileImageSection/ProfileReportModal.tsx
@@ -30,7 +30,7 @@ export default function ProfileReportModal({
     setSelected(e.target.value);
   const handleReportSumbit = () => {
     onClose();
-    snackBar?.open({ message: "신고가 접수되었습니다." });
+    snackBar.open({ message: "신고가 접수되었습니다." });
   };
 
   return (


### PR DESCRIPTION
## 📝 개요
snack bar 로직 변경


## 🚀 변경사항

- ### `App.tsx`에 `SnackBarContextProvider` 적용
```tsx
export default function App() {
  return (
      <SnackBarContextProvider>
         {children}
      </SnackBarContextProvider>
  );
}
```

- ### snackbar 기본 속성 변경
기본적으로 snackbar의 위치는 bottom, 지속시간은 2초 입니다.

다음과 같이 기본 속성을 변경할 수 있습니다.
```tsx
 <SnackBarContextProvider option={{ position: "top", duration: 10 }}>
```

-----------------

- ### snackbar 렌더링
   - `useSnackBar` 훅을 이용하면 됩니다. 
```tsx
export default function ProfileReportModal({
  onClose,
}: ProfileReportModalProps) {
  const snackBar = useSnackBar();
  const handleReportSumbit = () => {
    onClose();
    snackBar.open({ message: "신고가 접수되었습니다." });
  };
 // 생략 ...

 return (생략...)

}
```

- ### snackbar 개별 duration 변경
   - `SnackBarContextProvider` 에서 정의한 duration을 사용하지 않고, snackbar 각각의 duration으로 변경할 수 있습니다.

```tsx
snackBar.open({ message: "신고가 접수되었습니다.", duration: 7 });
```

------------

https://github.com/oduck-team/oduck-client/assets/115006670/cdafe11e-5255-43bf-8173-76cbebeec908



https://github.com/oduck-team/oduck-client/assets/115006670/e217a174-fa53-4521-a4e0-a513206cd992

- 클릭으로 snackbar를 제거할 수 있습니다.



## 🔗 관련 이슈
#208


## ➕ 기타


