### PR TITLE
feat: `SelectBox`의 dropdown 구현

### DIFF
--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 
+import useScrollLock from "@/hooks/useScrollLock";
+
 import {
   CaretIcon,
   DropDownList,
@@ -15,6 +17,8 @@ type Direction = typeof ARROW_UP | typeof ARROW_DOWN;
 const ARROW_UP = "ArrowUp";
 const ARROW_DOWN = "ArrowDown";
 const ENTER = "Enter";
+
+export type Position = "bottom" | "top";
 
 interface Option {
   value: string;
@@ -34,6 +38,8 @@ export default function SelectBox({
   onChange,
 }: SelectBoxProps) {
   const [listVisible, setListVisible] = useState(false);
+  useScrollLock(listVisible);
+  const [position, setPosition] = useState<Position>("bottom");
   const cursor = useRef(0);
   const selectBoxtRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
@@ -105,6 +111,22 @@ export default function SelectBox({
     };
   }, [keyHandler, listVisible]);
 
+  useEffect(() => {
+    if (listVisible) {
+      const windowHeight = window.innerHeight;
+      const listHeight = listRef.current?.offsetHeight ?? 0;
+      const selectBoxPosition =
+        selectBoxtRef.current?.getBoundingClientRect().bottom ?? 0;
+
+      if (windowHeight - selectBoxPosition < listHeight) {
+        setPosition("top");
+        return;
+      }
+
+      setPosition("bottom");
+    }
+  }, [listVisible]);
+
   return (
     <SelectBoxContainer ref={selectBoxtRef} tabIndex={0}>
       <Select selected={selected} onClick={handleListToggle}>
@@ -113,7 +135,7 @@ export default function SelectBox({
       </Select>
 
       {listVisible && (
-        <DropDownList ref={listRef}>
+        <DropDownList ref={listRef} position={position}>
           {options.map(({ value, text }, index) => (
             <Option
               key={value}

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -1,4 +1,12 @@
-import { CaretIcon, Option, Select, SelectBoxContainer } from "./style";
+import { useState } from "react";
+
+import {
+  CaretIcon,
+  DropDownList,
+  Option,
+  Select,
+  SelectBoxContainer,
+} from "./style";
 
 interface Option {
   value: string;
@@ -8,8 +16,8 @@ interface Option {
 export interface SelectBoxProps {
   options: Option[];
   /** option이 선택되면 SelectBox의 border 색상 변경 옵션 */
-  selected: string;
-  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  selected: Option;
+  onChange: (value: string, text: string) => void;
 }
 
 export default function SelectBox({
@@ -17,16 +25,28 @@ export default function SelectBox({
   selected,
   onChange,
 }: SelectBoxProps) {
+  const [listVisible, setListVisible] = useState(false);
+  const handleListToggle = () => setListVisible((prev) => !prev);
+  const handleOptionClick = (value: string, text: string) => {
+    onChange(value, text);
+    handleListToggle();
+  };
+
   return (
     <SelectBoxContainer>
-      <Select selected={selected} onChange={(e) => onChange(e)}>
-        {options.map(({ value, text }) => (
-          <Option key={value} value={value}>
-            {text}
-          </Option>
-        ))}
+      <Select selected={selected} onClick={handleListToggle}>
+        {selected.text}
+        <CaretIcon size={18} />
       </Select>
-      <CaretIcon size={18} />
+      {listVisible && (
+        <DropDownList>
+          {options.map(({ value, text }) => (
+            <Option key={value} onClick={() => handleOptionClick(value, text)}>
+              {text}
+            </Option>
+          ))}
+        </DropDownList>
+      )}
     </SelectBoxContainer>
   );
 }

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -100,6 +100,13 @@ export default function SelectBox({
     [onChange, options, scrollToSelectedOption],
   );
 
+  const closeList = (e: MouseEvent) => {
+    const selectBoxEl = selectBoxtRef.current;
+    if (selectBoxEl && !selectBoxEl.contains(e.target as Node)) {
+      setListVisible(false);
+    }
+  };
+
   useEffect(() => {
     const selectBoxEl = selectBoxtRef.current;
     if (listVisible) {
@@ -125,6 +132,13 @@ export default function SelectBox({
 
       setPosition("bottom");
     }
+  }, [listVisible]);
+
+  useEffect(() => {
+    if (!listVisible) return;
+
+    document.addEventListener("click", closeList);
+    return () => document.removeEventListener("click", closeList);
   }, [listVisible]);
 
   return (

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -1,26 +1,13 @@
-import { useEffect, useRef, useState, useCallback } from "react";
-
-import useScrollLock from "@/hooks/useScrollLock";
-
 import {
   CaretIcon,
   DropDownList,
-  OPTION_HEIGHT,
   Option,
-  SHOW_MAX_OPTION,
   Select,
   SelectBoxContainer,
 } from "./style";
+import useSelectBox from "./useSelectBox";
 
-type Direction = typeof ARROW_UP | typeof ARROW_DOWN;
-
-const ARROW_UP = "ArrowUp";
-const ARROW_DOWN = "ArrowDown";
-const ENTER = "Enter";
-
-export type Position = "bottom" | "top";
-
-interface Option {
+export interface Option {
   value: string;
   text: string;
 }
@@ -37,109 +24,15 @@ export default function SelectBox({
   selected,
   onChange,
 }: SelectBoxProps) {
-  const [listVisible, setListVisible] = useState(false);
-  useScrollLock(listVisible);
-  const [position, setPosition] = useState<Position>("bottom");
-  const cursor = useRef(0);
-  const selectBoxtRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<HTMLUListElement>(null);
-  const handleListToggle = () => setListVisible((prev) => !prev);
-  const handleOptionClick = (value: string, text: string, index: number) => {
-    onChange(value, text);
-    cursor.current = index;
-    handleListToggle();
-  };
-
-  const scrollToSelectedOption = useCallback(
-    (direction: Direction) => {
-      if (direction === "ArrowDown") {
-        cursor.current >= SHOW_MAX_OPTION
-          ? listRef.current?.scrollBy({ top: OPTION_HEIGHT })
-          : listRef.current?.scrollTo({ top: 0 });
-        return;
-      }
-
-      if (direction === "ArrowUp") {
-        cursor.current <= options.length - 1 - SHOW_MAX_OPTION
-          ? listRef.current?.scrollBy({ top: -OPTION_HEIGHT })
-          : listRef.current?.scrollTo({
-              top: listRef.current?.childElementCount * OPTION_HEIGHT,
-            });
-        return;
-      }
-    },
-    [options.length],
-  );
-
-  const keyHandler = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === ARROW_DOWN) {
-        cursor.current =
-          cursor.current < options.length - 1 ? cursor.current + 1 : 0;
-
-        onChange(options[cursor.current].value, options[cursor.current].text);
-        scrollToSelectedOption(e.key);
-        return;
-      }
-
-      if (e.key === ARROW_UP) {
-        cursor.current =
-          cursor.current > 0 ? cursor.current - 1 : options.length - 1;
-
-        onChange(options[cursor.current].value, options[cursor.current].text);
-        scrollToSelectedOption(e.key);
-        return;
-      }
-
-      if (e.key === ENTER) {
-        onChange(options[cursor.current].value, options[cursor.current].text);
-        handleListToggle();
-        return;
-      }
-    },
-    [onChange, options, scrollToSelectedOption],
-  );
-
-  const closeList = (e: MouseEvent) => {
-    const selectBoxEl = selectBoxtRef.current;
-    if (selectBoxEl && !selectBoxEl.contains(e.target as Node)) {
-      setListVisible(false);
-    }
-  };
-
-  useEffect(() => {
-    const selectBoxEl = selectBoxtRef.current;
-    if (listVisible) {
-      selectBoxEl?.addEventListener("keydown", keyHandler);
-    }
-
-    return () => {
-      selectBoxEl?.removeEventListener("keydown", keyHandler);
-    };
-  }, [keyHandler, listVisible]);
-
-  useEffect(() => {
-    if (listVisible) {
-      const windowHeight = window.innerHeight;
-      const listHeight = listRef.current?.offsetHeight ?? 0;
-      const selectBoxPosition =
-        selectBoxtRef.current?.getBoundingClientRect().bottom ?? 0;
-
-      if (windowHeight - selectBoxPosition < listHeight) {
-        setPosition("top");
-        return;
-      }
-
-      setPosition("bottom");
-    }
-  }, [listVisible]);
-
-  useEffect(() => {
-    if (!listVisible) return;
-
-    document.addEventListener("click", closeList);
-    return () => document.removeEventListener("click", closeList);
-  }, [listVisible]);
+  const {
+    selectBoxtRef,
+    listRef,
+    listVisible,
+    position,
+    cursor,
+    handleListToggle,
+    handleOptionClick,
+  } = useSelectBox(options, onChange);
 
   return (
     <SelectBoxContainer ref={selectBoxtRef} tabIndex={0}>

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -36,8 +36,9 @@ export default function SelectBox({
   const selectBoxtRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const handleListToggle = () => setListVisible((prev) => !prev);
-  const handleOptionClick = (value: string, text: string) => {
+  const handleOptionClick = (value: string, text: string, index: number) => {
     onChange(value, text);
+    cursor.current = index;
     handleListToggle();
   };
 
@@ -116,7 +117,7 @@ export default function SelectBox({
               key={value}
               index={index}
               cursor={cursor.current}
-              onClick={() => handleOptionClick(value, text)}
+              onClick={() => handleOptionClick(value, text, index)}
             >
               {text}
             </Option>

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -3,7 +3,9 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import {
   CaretIcon,
   DropDownList,
+  OPTION_HEIGHT,
   Option,
+  SHOW_MAX_OPTION,
   Select,
   SelectBoxContainer,
 } from "./style";
@@ -45,17 +47,17 @@ export default function SelectBox({
   const scrollToSelectedOption = useCallback(
     (direction: Direction) => {
       if (direction === "ArrowDown") {
-        cursor.current >= 6
-          ? listRef.current?.scrollBy({ top: 32 })
+        cursor.current >= SHOW_MAX_OPTION
+          ? listRef.current?.scrollBy({ top: OPTION_HEIGHT })
           : listRef.current?.scrollTo({ top: 0 });
         return;
       }
 
       if (direction === "ArrowUp") {
-        cursor.current <= options.length - 1 - 6
-          ? listRef.current?.scrollBy({ top: -32 })
+        cursor.current <= options.length - 1 - SHOW_MAX_OPTION
+          ? listRef.current?.scrollBy({ top: -OPTION_HEIGHT })
           : listRef.current?.scrollTo({
-              top: listRef.current?.childElementCount * 32,
+              top: listRef.current?.childElementCount * OPTION_HEIGHT,
             });
         return;
       }

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -45,18 +45,18 @@ export default function SelectBox({
   const scrollToSelectedOption = useCallback(
     (direction: Direction) => {
       if (direction === "ArrowDown") {
-        cursor.current === 0
-          ? listRef.current?.scrollTo({ top: 0 })
-          : listRef.current?.scrollBy({ top: 32 });
+        cursor.current >= 6
+          ? listRef.current?.scrollBy({ top: 32 })
+          : listRef.current?.scrollTo({ top: 0 });
         return;
       }
 
       if (direction === "ArrowUp") {
-        cursor.current === options.length - 1
-          ? listRef.current?.scrollTo({
+        cursor.current <= options.length - 1 - 6
+          ? listRef.current?.scrollBy({ top: -32 })
+          : listRef.current?.scrollTo({
               top: listRef.current?.childElementCount * 32,
-            })
-          : listRef.current?.scrollBy({ top: -32 });
+            });
         return;
       }
     },

--- a/src/components/SelectBox/style.ts
+++ b/src/components/SelectBox/style.ts
@@ -2,7 +2,9 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { CaretDown } from "@phosphor-icons/react";
 
-import { Position, SelectBoxProps } from ".";
+import { Position } from "./useSelectBox";
+
+import { SelectBoxProps } from ".";
 
 export const SHOW_MAX_OPTION = 6;
 export const OPTION_HEIGHT = 32;

--- a/src/components/SelectBox/style.ts
+++ b/src/components/SelectBox/style.ts
@@ -6,6 +6,7 @@ import { SelectBoxProps } from ".";
 
 export const SelectBoxContainer = styled.div`
   position: relative;
+  outline: none;
 `;
 
 export const Select = styled.div<Pick<SelectBoxProps, "selected">>`
@@ -60,7 +61,7 @@ export const DropDownList = styled.ul`
   overflow-y: scroll;
 `;
 
-export const Option = styled.li`
+export const Option = styled.li<{ index: number; cursor: number }>`
   color: ${({ theme }) => theme.colors.neutral[90]};
   ${({ theme }) => theme.typo["body-2-r"]}
   padding: 5px 13px 5px 5px;
@@ -70,6 +71,12 @@ export const Option = styled.li`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+
+  ${({ theme, index, cursor }) =>
+    index === cursor &&
+    css`
+      background-color: ${theme.colors.neutral[10]};
+    `}
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.neutral[10]};

--- a/src/components/SelectBox/style.ts
+++ b/src/components/SelectBox/style.ts
@@ -4,6 +4,9 @@ import { CaretDown } from "@phosphor-icons/react";
 
 import { SelectBoxProps } from ".";
 
+export const SHOW_MAX_OPTION = 6;
+export const OPTION_HEIGHT = 32;
+
 export const SelectBoxContainer = styled.div`
   position: relative;
   outline: none;
@@ -48,16 +51,19 @@ export const CaretIcon = styled(CaretDown)`
 `;
 
 export const DropDownList = styled.ul`
+  --padding: 8px;
   box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.08);
   border: 1px solid ${({ theme }) => theme.colors.neutral["05"]};
   border-radius: 6px;
   background-color: #fff;
-  padding: 8px;
+  padding: var(--padding);
   position: absolute;
   top: calc(40px + 2px);
   left: 0px;
   width: 100%;
-  max-height: calc((32px * 6) + 16px); // option height * 개수 + 위 아래 padding
+  max-height: calc(
+    (${OPTION_HEIGHT}px * ${SHOW_MAX_OPTION}) + (var(--padding) * 2)
+  );
   overflow-y: scroll;
 `;
 
@@ -66,8 +72,8 @@ export const Option = styled.li<{ index: number; cursor: number }>`
   ${({ theme }) => theme.typo["body-2-r"]}
   padding: 5px 13px 5px 5px;
   border-radius: 6px;
-  height: 32px; // option height
-  max-height: 32px;
+  height: ${OPTION_HEIGHT}px;
+  max-height: ${OPTION_HEIGHT}px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/src/components/SelectBox/style.ts
+++ b/src/components/SelectBox/style.ts
@@ -8,14 +8,15 @@ export const SelectBoxContainer = styled.div`
   position: relative;
 `;
 
-export const Select = styled.select<Pick<SelectBoxProps, "selected">>`
+export const Select = styled.div<Pick<SelectBoxProps, "selected">>`
+  position: relative;
   color: ${({ theme }) => theme.colors.neutral[90]};
   width: 100%;
   padding: 9px 40px 9px 14px;
   outline: none;
   border: 1px solid ${({ theme }) => theme.colors.neutral[30]};
   border-radius: 6px;
-  min-height: 40px;
+  max-height: 40px;
   user-select: none;
   overflow: hidden;
   white-space: nowrap;
@@ -36,11 +37,6 @@ export const Select = styled.select<Pick<SelectBoxProps, "selected">>`
   }
 `;
 
-export const Option = styled.option`
-  color: ${({ theme }) => theme.colors.neutral[90]};
-  ${({ theme }) => theme.typo["body-2-r"]}
-`;
-
 export const CaretIcon = styled(CaretDown)`
   position: absolute;
   right: 14px;
@@ -48,4 +44,34 @@ export const CaretIcon = styled(CaretDown)`
   transform: translateY(-50%);
   pointer-events: none;
   color: ${({ theme }) => theme.colors.neutral[50]};
+`;
+
+export const DropDownList = styled.ul`
+  box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.08);
+  border: 1px solid ${({ theme }) => theme.colors.neutral["05"]};
+  border-radius: 6px;
+  background-color: #fff;
+  padding: 8px;
+  position: absolute;
+  top: calc(40px + 2px);
+  left: 0px;
+  width: 100%;
+  max-height: calc((32px * 6) + 16px); // option height * 개수 + 위 아래 padding
+  overflow-y: scroll;
+`;
+
+export const Option = styled.li`
+  color: ${({ theme }) => theme.colors.neutral[90]};
+  ${({ theme }) => theme.typo["body-2-r"]}
+  padding: 5px 13px 5px 5px;
+  border-radius: 6px;
+  height: 32px; // option height
+  max-height: 32px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.neutral[10]};
+  }
 `;

--- a/src/components/SelectBox/style.ts
+++ b/src/components/SelectBox/style.ts
@@ -55,7 +55,7 @@ export const CaretIcon = styled(CaretDown)`
 export const DropDownList = styled.ul<{ position: Position }>`
   --padding: 8px;
   box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.08);
-  border: 1px solid ${({ theme }) => theme.colors.neutral[40]};
+  border: 1px solid ${({ theme }) => theme.colors.neutral[20]};
   border-radius: 6px;
   background-color: #fff;
   padding: var(--padding);

--- a/src/components/SelectBox/style.ts
+++ b/src/components/SelectBox/style.ts
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { CaretDown } from "@phosphor-icons/react";
 
-import { SelectBoxProps } from ".";
+import { Position, SelectBoxProps } from ".";
 
 export const SHOW_MAX_OPTION = 6;
 export const OPTION_HEIGHT = 32;
@@ -50,10 +50,10 @@ export const CaretIcon = styled(CaretDown)`
   color: ${({ theme }) => theme.colors.neutral[50]};
 `;
 
-export const DropDownList = styled.ul`
+export const DropDownList = styled.ul<{ position: Position }>`
   --padding: 8px;
   box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.08);
-  border: 1px solid ${({ theme }) => theme.colors.neutral["05"]};
+  border: 1px solid ${({ theme }) => theme.colors.neutral[40]};
   border-radius: 6px;
   background-color: #fff;
   padding: var(--padding);
@@ -65,6 +65,16 @@ export const DropDownList = styled.ul`
     (${OPTION_HEIGHT}px * ${SHOW_MAX_OPTION}) + (var(--padding) * 2)
   );
   overflow-y: scroll;
+  z-index: ${({ theme }) => theme.zIndex.modal};
+
+  ${({ position }) =>
+    position === "top" &&
+    css`
+      top: calc(
+        -1 * ((${OPTION_HEIGHT}px * ${SHOW_MAX_OPTION}) + (var(--padding) * 2) +
+              4px)
+      );
+    `}
 `;
 
 export const Option = styled.li<{ index: number; cursor: number }>`

--- a/src/components/SelectBox/useSelectBox.ts
+++ b/src/components/SelectBox/useSelectBox.ts
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+
+import useScrollLock from "@/hooks/useScrollLock";
+
+import { OPTION_HEIGHT, SHOW_MAX_OPTION } from "./style";
+
+import { Option } from ".";
+
+type Direction = typeof ARROW_UP | typeof ARROW_DOWN;
+
+const ARROW_UP = "ArrowUp";
+const ARROW_DOWN = "ArrowDown";
+const ENTER = "Enter";
+
+export type Position = "bottom" | "top";
+
+export default function useSelectBox(
+  options: Option[],
+  onChange: (value: string, text: string) => void,
+) {
+  const [listVisible, setListVisible] = useState(false);
+  useScrollLock(listVisible);
+  const [position, setPosition] = useState<Position>("bottom");
+  const cursor = useRef(0);
+  const selectBoxtRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const handleListToggle = () => setListVisible((prev) => !prev);
+  const handleOptionClick = (value: string, text: string, index: number) => {
+    onChange(value, text);
+    cursor.current = index;
+    handleListToggle();
+  };
+
+  const scrollToSelectedOption = useCallback(
+    (direction: Direction) => {
+      if (direction === "ArrowDown") {
+        cursor.current >= SHOW_MAX_OPTION
+          ? listRef.current?.scrollBy({ top: OPTION_HEIGHT })
+          : listRef.current?.scrollTo({ top: 0 });
+        return;
+      }
+
+      if (direction === "ArrowUp") {
+        cursor.current <= options.length - 1 - SHOW_MAX_OPTION
+          ? listRef.current?.scrollBy({ top: -OPTION_HEIGHT })
+          : listRef.current?.scrollTo({
+              top: listRef.current?.childElementCount * OPTION_HEIGHT,
+            });
+        return;
+      }
+    },
+    [options.length],
+  );
+
+  const keyHandler = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === ARROW_DOWN) {
+        cursor.current =
+          cursor.current < options.length - 1 ? cursor.current + 1 : 0;
+
+        onChange(options[cursor.current].value, options[cursor.current].text);
+        scrollToSelectedOption(e.key);
+        return;
+      }
+
+      if (e.key === ARROW_UP) {
+        cursor.current =
+          cursor.current > 0 ? cursor.current - 1 : options.length - 1;
+
+        onChange(options[cursor.current].value, options[cursor.current].text);
+        scrollToSelectedOption(e.key);
+        return;
+      }
+
+      if (e.key === ENTER) {
+        onChange(options[cursor.current].value, options[cursor.current].text);
+        handleListToggle();
+        return;
+      }
+    },
+    [onChange, options, scrollToSelectedOption],
+  );
+
+  const closeList = (e: MouseEvent) => {
+    const selectBoxEl = selectBoxtRef.current;
+    if (selectBoxEl && !selectBoxEl.contains(e.target as Node)) {
+      setListVisible(false);
+    }
+  };
+
+  /** 엔터, 위 아래 방향키 이벤트 처리 */
+  useEffect(() => {
+    if (!listVisible) return;
+
+    const selectBoxEl = selectBoxtRef.current;
+    selectBoxEl?.addEventListener("keydown", keyHandler);
+
+    return () => {
+      selectBoxEl?.removeEventListener("keydown", keyHandler);
+    };
+  }, [keyHandler, listVisible]);
+
+  /** viewport 하단 영역이 부족한 경우, list를 상단에 렌더링 */
+  useEffect(() => {
+    if (!listVisible) return;
+
+    const windowHeight = window.innerHeight;
+    const listHeight = listRef.current?.offsetHeight ?? 0;
+    const selectBoxPosition =
+      selectBoxtRef.current?.getBoundingClientRect().bottom ?? 0;
+
+    if (windowHeight - selectBoxPosition < listHeight) {
+      setPosition("top");
+      return;
+    }
+
+    setPosition("bottom");
+  }, [listVisible]);
+
+  /** dropdown list 바깥 영역 클릭 시, list 닫기 */
+  useEffect(() => {
+    if (!listVisible) return;
+
+    document.addEventListener("click", closeList);
+    return () => document.removeEventListener("click", closeList);
+  }, [listVisible]);
+
+  return {
+    selectBoxtRef,
+    listRef,
+    listVisible,
+    position,
+    cursor,
+    handleListToggle,
+    handleOptionClick,
+  };
+}

--- a/src/features/users/components/ProfileImageSection/ProfileReportModal.tsx
+++ b/src/features/users/components/ProfileImageSection/ProfileReportModal.tsx
@@ -14,6 +14,17 @@ const OPTION = [
     text: "부적절한 닉네임/자기소개",
   },
   { value: "기타 신고", text: "기타 신고" },
+  {
+    value:
+      "텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1",
+    text: "텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1텍스트1",
+  },
+  { value: "2", text: "2" },
+  { value: "텍스트3", text: "텍스트3" },
+  { value: "텍스트4", text: "텍스트4" },
+  { value: "텍스트5", text: "텍스트5" },
+  { value: "텍스트6", text: "텍스트6" },
+  { value: "텍스트7", text: "텍스트7" },
 ];
 
 interface ProfileReportModalProps {
@@ -24,10 +35,14 @@ export default function ProfileReportModal({
   onClose,
 }: ProfileReportModalProps) {
   const snackBar = useSnackBar();
-  const [selected, setSelected] = useState(OPTION[0].value);
+  const [selected, setSelected] = useState({
+    value: OPTION[0].value,
+    text: OPTION[0].text,
+  });
 
-  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) =>
-    setSelected(e.target.value);
+  const handleSelectChange = (value: string, text: string) =>
+    setSelected({ value, text });
+
   const handleReportSumbit = () => {
     onClose();
     snackBar.open({ message: "신고가 접수되었습니다." });


### PR DESCRIPTION
## 📝 개요
`SelectBox`의 dropdown 구현


## 🚀 변경사항
### - dropdown 구현
![image](https://github.com/oduck-team/oduck-client/assets/115006670/19f15890-fc3c-4bf9-853d-a44aa7d5c8fc)

### - 방향키 위, 아래, 엔터 이벤트

https://github.com/oduck-team/oduck-client/assets/115006670/1c3fcee1-b392-4f29-b6c1-0dfb99116bdb

### - viewport 하단 영역이 부족한 경우, list를 상단에 렌더링


https://github.com/oduck-team/oduck-client/assets/115006670/6f119f3f-5698-4f98-b040-f4eebda4e8de



## 🔗 관련 이슈

#218

## ➕ 기타

데스크탑에서 `useScrollLock` 이 실행되면 브라우저의 스크롤바 영역이 사라져서, 화면이 덜컹거리는 느낌이 있습니다..! 이 부분은 수정하면 좋을 거 같습니다.

