### PR TITLE
feat: 애니 등록 공개 여부 추가, 이미지 등록후 반환 url 수정

### DIFF
--- a/src/admins/features/animes/api/AdminAnimeApi.ts
+++ b/src/admins/features/animes/api/AdminAnimeApi.ts
@@ -3,20 +3,35 @@ import AnimeApi from "@/features/animes/api/AnimeApi";
 import { post } from "@/libs/api";
 
 export interface CreateAnimeDto {
+  /** 시리즈 id */
   seriesId: number;
+  /** 제목 */
   title: string;
+  /** 줄거리 */
   summary: string;
+  /** 방영 종류 */
   broadcastType: BroadcastType;
+  /** 에피소드 수 */
   episodeCount: number;
+  /** 썸네일 이미지 경로 */
   thumbnail: string;
+  /** 년도 */
   year: number;
+  /** 분기 */
   quarter: AnimeQuarter;
+  /** 시청연령 */
   rating: AnimeRating;
+  /** 방영 상태 */
   status: AnimeStatus;
-  // isReleased: boolean;
+  /** 사용자들에게 공개 여부 */
+  isReleased: boolean;
+  /** 원작자 id 목록 */
   originalAuthorIds: number[];
+  /** 제작사 id 목록 */
   studioIds: number[];
+  /** 성우 id 목록 */
   voiceActors: { id: number; name: string; part: string }[];
+  /** 장르 id 목록 */
   genreIds: number[];
 }
 

--- a/src/admins/features/animes/components/AdminCreateAnimeForm.tsx
+++ b/src/admins/features/animes/components/AdminCreateAnimeForm.tsx
@@ -2,7 +2,6 @@ import {
   Flex,
   Input,
   Stack,
-  Image,
   Select,
   TextInput,
   Text,
@@ -12,6 +11,8 @@ import {
   MultiSelect,
   Button,
   Table,
+  Switch,
+  Title,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
@@ -22,7 +23,6 @@ import DateSelect from "@/admins/components/Form/DateSelect";
 import Form from "@/admins/components/Form/Form";
 import ImageDropzone from "@/admins/components/Form/ImageDropzone";
 import ADMIN_ROUTE from "@/admins/constants/path";
-import { CDN_URL } from "@/config";
 
 import useCreateAnime from "../hooks/useCreateAnime";
 import useCreateGenre from "../hooks/useCreateGenre";
@@ -35,6 +35,7 @@ import useSeries from "../hooks/useSeries";
 import useStudios from "../hooks/useStudios";
 
 import AnimeFormActions from "./AdminFormActions";
+import AnimePreviewCard from "./AnimePreviewCard";
 import CreateSubCategoryButton from "./CreateSubCategoryButton";
 import EditVoiceActorsModal from "./EditVoiceActorsModal";
 
@@ -96,6 +97,7 @@ export default function AdminCreateAnimeForm() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    console.log(form.values);
     form.validate();
     if (!form.isValid()) {
       return;
@@ -154,7 +156,28 @@ export default function AdminCreateAnimeForm() {
       <Flex justify="end" mb="sm">
         <AnimeFormActions mode="create" onAction={handleSubmit} />
       </Flex>
+
+      <Stack p="md" mb="md" bg="gray.0" style={{ borderRadius: 12 }}>
+        <Title size="h5">미리보기</Title>
+        <AnimePreviewCard
+          title={form.values.title}
+          thumbnail={form.values.thumbnail}
+        />
+      </Stack>
+
       <Stack gap="xl">
+        <Input.Wrapper
+          label="공개여부"
+          withAsterisk
+          inputWrapperOrder={INPUT_WRAPPER_ORDER}
+        >
+          <Switch
+            label="사용자들에게 공개합니다"
+            onChange={(e) =>
+              form.setFieldValue("isReleased", e.currentTarget.checked)
+            }
+          />
+        </Input.Wrapper>
         <Input.Wrapper
           label="썸네일"
           withAsterisk
@@ -167,15 +190,6 @@ export default function AdminCreateAnimeForm() {
               form.setFieldValue("thumbnail", path);
             }}
           />
-          {form.values.thumbnail && (
-            <Image
-              alt="썸네일"
-              src={`${CDN_URL}${form.values.thumbnail}`}
-              width="auto"
-              height="260"
-              p="sm"
-            />
-          )}
         </Input.Wrapper>
 
         <Flex align="end" gap="sm">

--- a/src/admins/features/animes/components/AnimePreviewCard.style.ts
+++ b/src/admins/features/animes/components/AnimePreviewCard.style.ts
@@ -1,0 +1,77 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+
+interface CardProps {
+  size?: "md" | "lg";
+}
+
+interface ImageProps extends CardProps {
+  image: string;
+}
+
+export const AnimeCardContainer = styled.div<CardProps>`
+  width: ${({ size = "md" }) => (size === "md" ? `160px` : `100%`)};
+  flex-shrink: 0;
+  & > a {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+`;
+
+export const Image = styled.div<ImageProps>`
+  width: 100%;
+  height: ${({ size = "md" }) => (size === "md" ? `110px` : `152px`)};
+  border-radius: 5px;
+  ${({ image }) => css`
+    background:
+      url(${image}),
+      lightgray 50% no-repeat;
+  `}
+  background-size: cover;
+  background-position: center;
+`;
+
+export const InfoContainer = styled.div<CardProps>`
+  width: 100%;
+  height: ${({ size = "md" }) => (size === "md" ? `65px` : `fit-content`)};
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+`;
+
+export const Title = styled.div`
+  ${({ theme }) => theme.typo["body-2-r"]};
+  color: ${({ theme }) => theme.colors["neutral"]["90"]};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-all;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+`;
+
+export const Rating = styled.div`
+  display: flex;
+  width: 39px;
+  height: 21px;
+  justify-content: center;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+
+  & > span {
+    ${({ theme }) => theme.typo["body-2-r"]};
+    color: ${({ theme }) => theme.colors["neutral"]["70"]};
+  }
+
+  & > svg {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    color: ${({ theme }) => theme.colors["primary"]["60"]};
+    fill: ${({ theme }) => theme.colors["primary"]["60"]};
+  }
+`;

--- a/src/admins/features/animes/components/AnimePreviewCard.tsx
+++ b/src/admins/features/animes/components/AnimePreviewCard.tsx
@@ -1,0 +1,36 @@
+import { Star } from "@phosphor-icons/react";
+
+import {
+  AnimeCardContainer,
+  Image,
+  InfoContainer,
+  Rating,
+  Title,
+} from "./AnimePreviewCard.style";
+
+interface AnimeCardProps {
+  title?: string;
+  thumbnail?: string;
+  size?: "md" | "lg";
+}
+
+export default function AnimePreviewCard({
+  title = "제목을 입력하세요",
+  thumbnail,
+  size,
+}: AnimeCardProps) {
+  return (
+    <AnimeCardContainer size={size}>
+      <Image image={thumbnail ? thumbnail : "/logo/logo.png"} size={size} />
+      <InfoContainer size={size}>
+        <Title>{title.length === 0 ? "제목을 입력하세요" : title} </Title>
+        <Rating>
+          <Star weight="fill" />
+          {/* TODO: 응답타입 불명확함 */}
+          {/* <span> {anime.rating}</span> */}
+          <span> 5.0 </span>
+        </Rating>
+      </InfoContainer>
+    </AnimeCardContainer>
+  );
+}

--- a/src/admins/features/animes/hooks/useCreateAnime.ts
+++ b/src/admins/features/animes/hooks/useCreateAnime.ts
@@ -10,6 +10,7 @@ import useAnimeForm from "./useAnimeForm";
 export default function useCreateAnime() {
   const { animeApi } = useAdminApi();
   const form = useAnimeForm({
+    isReleased: false,
     seriesId: 0,
     title: "",
     summary: "",

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -7,9 +7,12 @@ import {
   UserCircle,
   X,
 } from "@phosphor-icons/react";
+import { AnimatePresence } from "framer-motion";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
 
+import LoginAlertModal from "@/features/auth/components/LoginAlertModal";
 import useAuth from "@/features/auth/hooks/useAuth";
 
 import Avatar from "../Avatar";
@@ -62,12 +65,16 @@ export default function Sidebar({
   onClose,
 }: SidebarProps) {
   const { user, isLoggedIn, logout } = useAuth();
+  const [isLoginModalVisible, setIsLoginModalVisible] = useState(false);
   const navigate = useNavigate();
 
   const handleClickUserMenu = (id: string, e: React.MouseEvent) => {
     e.preventDefault();
 
-    if (!isLoggedIn) navigate("/login", { replace: true });
+    if (!isLoggedIn) {
+      setIsLoginModalVisible(true);
+      return;
+    }
 
     const foundItem = userMenuItems.find((item) => item.id === id);
 
@@ -154,6 +161,11 @@ export default function Sidebar({
           )}
         </Navigation.Content>
       </Navigation>
+      <AnimatePresence>
+        {isLoginModalVisible && (
+          <LoginAlertModal onClose={() => setIsLoginModalVisible(false)} />
+        )}
+      </AnimatePresence>
     </Drawer>
   );
 }

--- a/src/features/files/api/FileApi.ts
+++ b/src/features/files/api/FileApi.ts
@@ -24,6 +24,6 @@ export default class FileApi {
       },
     });
 
-    return `/${path}/${filename}`;
+    return `https://cdn.oduck.io/static/${path}/${filename}`;
   }
 }

--- a/src/features/files/api/FileApi.ts
+++ b/src/features/files/api/FileApi.ts
@@ -22,6 +22,7 @@ export default class FileApi {
         Accept: "application/json",
         "Content-Type": file.type,
       },
+      withCredentials: false,
     });
 
     return `https://cdn.oduck.io/static/${path}/${filename}`;

--- a/src/libs/api/index.ts
+++ b/src/libs/api/index.ts
@@ -7,6 +7,7 @@ import { BASE_URL } from "@/config";
 const instance = axios.create({
   baseURL: BASE_URL,
   timeout: 3 * 1000,
+  withCredentials: true,
 });
 
 // Request interceptor


### PR DESCRIPTION
## 📝 개요

- 애니 등록시 공개여부 toggle을 추가 함
- 애니 카드 img src에 값을 바로 넣을 수 있게 이미지 등록후 반환 urll을 수정함
  - 기존에는 이미지 Url을 DB에 `/thmbnail/uuid`로 저장하여  `<img src={${CDN_URL}${thumbnail}}>` 이었으나, `https://cdn.oduck.../thmbnail/uuid`로 저장하여 `<img src{thumbnail}`로 쓸수있게함
- 애니 등록시 미리보기 추가
## 🚀 변경사항
- 요청에 다른 domain(api.oduck.io)에 쿠키를 보내기 위해 `withCredentials` 값 설정
```ts
const instance = axios.create({
  baseURL: BASE_URL,
  timeout: 3 * 1000,
  withCredentials: true,
});
```
- 파일 등록시에는 꺼서 사용해야 함
```ts
export default class FileApi {
  /**
   * @description R2 스토리지에 이미지를 업로드합니다. 중첩된 경로일 경우, 중첩 경로마다 `/`를 넣어야합니다.
   * @example - 일반 path: 'profile', filename: 'user-image', file: file
   * @example - 중첩 path: 'user/profile', filename: 'user-image', file: file
   * @returns `"/path/filename"`
   */
  async uploadImage({ path, filename, file }: UploadImageDto) {
    const signedUrl = await getSignedR2Url(path, filename);

    await put(signedUrl, file, {
      headers: {
        Accept: "application/json",
        "Content-Type": file.type,
      },
      withCredentials: false,
    });
```





- [refactor: 사이드바 미로그인 사용자 경험 개선](https://github.com/oduck-team/oduck-client/commit/b7d3fbf996c891456d682eb1515926526693b752)
사이드바에서 미로그인후 항목 클릭시 `로그인이 필요해요` 모달 등장하도록 수정
- 애니 등록시 미리보기 추가

https://github.com/oduck-team/oduck-client/assets/105474635/450e62f1-6fec-4a9d-842a-58ae53e96c18
## 🔗 관련 이슈

#262

## ➕ 기타

- 로그인 모달이 이곳저곳 사용되는데 전역으로 관리해야하나? 생각이 드네요

