### PR TITLE
feat: 프로필 페이지 변경사항 적용

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -10,10 +10,10 @@ import {
 import { AnimatePresence } from "framer-motion";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { v4 as uuidv4 } from "uuid";
 
 import LoginAlertModal from "@/features/auth/components/LoginAlertModal";
 import useAuth from "@/features/auth/hooks/useAuth";
+import { BOOKMARK } from "@/features/users/hooks/useTabMenu";
 
 import Avatar from "../Avatar";
 import Button from "../Button";
@@ -81,9 +81,7 @@ export default function Sidebar({
     if (foundItem) {
       onClickItem();
       if (foundItem.id === "bookmark") {
-        navigate(foundItem.to, {
-          state: `bookmark ${uuidv4()}`,
-        });
+        navigate({ pathname: "/profile", search: `?tab=${BOOKMARK}` });
       } else {
         navigate(foundItem.to);
       }

--- a/src/features/common/routes/Home/RecentReview/index.tsx
+++ b/src/features/common/routes/Home/RecentReview/index.tsx
@@ -5,6 +5,7 @@ import { Header, RecentReviewContainer, Title, ReviewConainer } from "./style";
 
 const REVIEW_MOCK_DATA = {
   animation: {
+    animeId: 1,
     title: "레벨 1이지만 유니크 스킬로 최강이 되었습니다",
     thumbnail:
       "https://i.namu.wiki/i/v8ca2gF_MPV_L4QZGoN449G29Nt8vy3PtSLKv1T9XwmZBJ8p1GTz3S3Y32sXB-eoGDv5npoGXzpD6fASoQFLwg.webp",
@@ -28,7 +29,11 @@ export default function RecentReview() {
         </Button>
       </Header>
       <ReviewConainer>
-        <ReviewCard isBlock border="none">
+        <ReviewCard
+          isBlock
+          border="none"
+          linkTo={`/animes/${REVIEW_MOCK_DATA.animation.animeId}`}
+        >
           <ReviewCard.Anime anime={REVIEW_MOCK_DATA.animation} />
           <ReviewCard.Comment
             text={REVIEW_MOCK_DATA.comment}

--- a/src/features/common/routes/Home/RecentReview/index.tsx
+++ b/src/features/common/routes/Home/RecentReview/index.tsx
@@ -28,7 +28,7 @@ export default function RecentReview() {
         </Button>
       </Header>
       <ReviewConainer>
-        <ReviewCard>
+        <ReviewCard isBlock border="none">
           <ReviewCard.Anime anime={REVIEW_MOCK_DATA.animation} />
           <ReviewCard.Comment
             text={REVIEW_MOCK_DATA.comment}

--- a/src/features/common/routes/Home/RecentReview/style.ts
+++ b/src/features/common/routes/Home/RecentReview/style.ts
@@ -5,7 +5,6 @@ export const RecentReviewContainer = styled.section`
   display: flex;
   flex-direction: column;
   gap: 8px;
-  border-bottom: solid 1px ${({ theme }) => theme.colors["neutral"]["05"]};
 `;
 
 export const Header = styled.div`
@@ -22,5 +21,7 @@ export const Title = styled.h1`
 `;
 
 export const ReviewConainer = styled.div`
+  border-top: solid 2px ${({ theme }) => theme.colors["neutral"]["05"]};
+  border-bottom: solid 2px ${({ theme }) => theme.colors["neutral"]["05"]};
   padding: 0 16px;
 `;

--- a/src/features/reviews/components/ReviewCard/ActionBar.style.ts
+++ b/src/features/reviews/components/ReviewCard/ActionBar.style.ts
@@ -6,8 +6,9 @@ import { ActionBarProps, Include } from "./ActionBar";
 export const ActionBarContainer = styled.div<Pick<ActionBarProps, "include">>`
   ${({ theme }) => theme.typo["body-3-r"]}
   color: #adaeb8;
+  cursor: default;
 
-  ${({ include = "common" }) => getActionBarContainerStyle(include)}
+  ${({ include = "common" }) => getActionBarContainerStyle(include)};
 `;
 
 export const ButtonContainer = styled.div<Pick<ActionBarProps, "include">>`
@@ -20,10 +21,10 @@ function getActionBarContainerStyle(include: Include) {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      margin-top: 8px;
+      padding-top: 8px;
     `,
     common: css`
-      margin-top: 16px;
+      padding-top: 16px;
     `,
   };
 

--- a/src/features/reviews/components/ReviewCard/ActionBar.style.ts
+++ b/src/features/reviews/components/ReviewCard/ActionBar.style.ts
@@ -6,7 +6,6 @@ import { ActionBarProps, Include } from "./ActionBar";
 export const ActionBarContainer = styled.div<Pick<ActionBarProps, "include">>`
   ${({ theme }) => theme.typo["body-3-r"]}
   color: #adaeb8;
-  cursor: default;
 
   ${({ include = "common" }) => getActionBarContainerStyle(include)};
 `;

--- a/src/features/reviews/components/ReviewCard/ActionBar.tsx
+++ b/src/features/reviews/components/ReviewCard/ActionBar.tsx
@@ -25,7 +25,7 @@ export default function ActionBar({
   const date = isTimeAgo ? timeAgo(createdAt) : dateWithDots(createdAt);
 
   return (
-    <ActionBarContainer include={include}>
+    <ActionBarContainer include={include} onClick={(e) => e.stopPropagation()}>
       {include === "time" && date && <time>{date}</time>}
       <ButtonContainer include={include}>
         <ReviewLikeButton

--- a/src/features/reviews/components/ReviewCard/ActionBar.tsx
+++ b/src/features/reviews/components/ReviewCard/ActionBar.tsx
@@ -25,9 +25,9 @@ export default function ActionBar({
   const date = isTimeAgo ? timeAgo(createdAt) : dateWithDots(createdAt);
 
   return (
-    <ActionBarContainer include={include} onClick={(e) => e.stopPropagation()}>
+    <ActionBarContainer include={include}>
       {include === "time" && date && <time>{date}</time>}
-      <ButtonContainer include={include}>
+      <ButtonContainer include={include} onClick={(e) => e.stopPropagation()}>
         <ReviewLikeButton
           isLike={isLike}
           count={compactNumber(likeCount, "ko-KR")}

--- a/src/features/reviews/components/ReviewCard/ReviewLikeButton.style.ts
+++ b/src/features/reviews/components/ReviewCard/ReviewLikeButton.style.ts
@@ -15,14 +15,24 @@ export const ReviewLikeButtonContainer = styled.button<
   cursor: pointer;
   ${({ theme }) => theme.typo["body-3-r"]}
 
+  @media(hover: hover) and (pointer: fine) {
+    &:hover {
+      & * {
+        color: ${({ theme }) => theme.colors.neutral["70"]};
+      }
+    }
+  }
+
   & > span {
     margin-left: 4px;
     color: ${({ theme }) => theme.colors.neutral["50"]};
+    transition: color ease 0.1s;
   }
 
   & > svg {
     color: ${({ isLike, theme }) =>
       isLike ? colors.red["40"] : theme.colors.neutral["50"]};
     fill: ${({ isLike }) => (isLike ? colors.red["40"] : "")};
+    transition: color ease 0.1s;
   }
 `;

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.style.ts
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.style.ts
@@ -1,5 +1,15 @@
 import styled from "@emotion/styled";
 
+import Button from "@/components/Button";
+
+export const MoreButton = styled(Button)`
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${({ theme }) => theme.colors.neutral[10]};
+    }
+  }
+`;
+
 export const MyRating = styled.span`
   display: block;
   ${({ theme }) => theme.typo["body-2-m"]}

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
@@ -4,7 +4,6 @@ import { AnimatePresence } from "framer-motion";
 import { useState } from "react";
 
 import BackdropPortal from "@/components/Backdrop/BackdropPortal";
-import Button from "@/components/Button";
 import Rating from "@/components/Rating";
 import useSnackBar from "@/components/SnackBar/useSnackBar";
 import DropDownModal from "@/features/users/components/DropDownModal";
@@ -12,7 +11,11 @@ import useDropDownModal from "@/features/users/components/DropDownModal/useDropD
 
 import ShortReviewModal from "../ReviewRating/ShortReviewModal";
 
-import { MyRating, RatingContainer } from "./ReviewMoreButton.style";
+import {
+  MoreButton,
+  MyRating,
+  RatingContainer,
+} from "./ReviewMoreButton.style";
 
 const USER_MOCK_REVIEW_DATA = {
   id: 1,
@@ -70,7 +73,7 @@ export default function ReviewMoreButton({ isMine }: ReviewMoreButtonProps) {
 
   return (
     <>
-      <Button
+      <MoreButton
         name="더보기"
         icon={<DotsThree color={theme.colors.neutral["50"]} />}
         variant="text"

--- a/src/features/reviews/components/ReviewCard/SpoilerComment.style.ts
+++ b/src/features/reviews/components/ReviewCard/SpoilerComment.style.ts
@@ -10,6 +10,14 @@ export const SpoilerCommentContainer = styled.div`
   border: none;
   border-radius: 10px;
   background-color: ${({ theme }) => theme.colors.neutral["05"]};
+  transition: background-color ease-in-out 0.1s;
+  cursor: default;
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${({ theme }) => theme.colors.neutral[10]};
+    }
+  }
 `;
 
 export const Info = styled.span`

--- a/src/features/reviews/components/ReviewCard/SpoilerComment.tsx
+++ b/src/features/reviews/components/ReviewCard/SpoilerComment.tsx
@@ -6,7 +6,7 @@ interface SpoilerCommentProps {
 
 export default function SpoilerComment({ onClick }: SpoilerCommentProps) {
   return (
-    <SpoilerCommentContainer>
+    <SpoilerCommentContainer onClick={(e) => e.stopPropagation()}>
       <Info>스포일러를 포함한 리뷰에요!</Info>
       <Button type="button" onClick={onClick}>
         리뷰보기

--- a/src/features/reviews/components/ReviewCard/index.tsx
+++ b/src/features/reviews/components/ReviewCard/index.tsx
@@ -11,15 +11,22 @@ export interface ReviewCardProps {
   isBlock?: boolean;
   /** border top을 생기게 하는 옵션 */
   isBorderTop?: boolean;
+  onClick?: () => void;
 }
 
 export default function ReviewCard({
   isBlock,
   isBorderTop = true,
+  onClick,
   children,
 }: StrictPropsWithChildren<ReviewCardProps>) {
   return (
-    <ReviewCardContainer isBlock={isBlock} isBorderTop={isBorderTop}>
+    <ReviewCardContainer
+      isBlock={isBlock}
+      isBorderTop={isBorderTop}
+      cursorPointer={onClick ? true : false}
+      onClick={() => onClick && onClick()}
+    >
       {children}
     </ReviewCardContainer>
   );

--- a/src/features/reviews/components/ReviewCard/index.tsx
+++ b/src/features/reviews/components/ReviewCard/index.tsx
@@ -6,24 +6,26 @@ import ReviewComent from "./ReviewComent";
 import { ReviewCardContainer } from "./style";
 import UserRating from "./UserRating";
 
+export type Border = "bottom" | "top" | "none";
+
 export interface ReviewCardProps {
   /** side-padding(16px)만큼 width를 늘리는 옵션 */
   isBlock?: boolean;
-  /** border top을 생기게 하는 옵션 */
-  isBorderTop?: boolean;
+  /** border에 관한 옵션(기본적으로 bottom을 가지고 있음) */
+  border?: Border;
   onClick?: () => void;
 }
 
 export default function ReviewCard({
   isBlock,
-  isBorderTop = true,
+  border = "bottom",
   onClick,
   children,
 }: StrictPropsWithChildren<ReviewCardProps>) {
   return (
     <ReviewCardContainer
       isBlock={isBlock}
-      isBorderTop={isBorderTop}
+      border={border}
       cursorPointer={onClick ? true : false}
       onClick={() => onClick && onClick()}
     >

--- a/src/features/reviews/components/ReviewCard/index.tsx
+++ b/src/features/reviews/components/ReviewCard/index.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from "react-router-dom";
+
 import { StrictPropsWithChildren } from "@/types";
 
 import ActionBar from "./ActionBar";
@@ -13,21 +15,25 @@ export interface ReviewCardProps {
   isBlock?: boolean;
   /** border에 관한 옵션(기본적으로 bottom을 가지고 있음) */
   border?: Border;
-  onClick?: () => void;
+  linkTo?: string;
 }
 
 export default function ReviewCard({
   isBlock,
   border = "bottom",
-  onClick,
+  linkTo,
   children,
 }: StrictPropsWithChildren<ReviewCardProps>) {
+  const navigate = useNavigate();
+  const handleClick = () => {
+    linkTo && navigate(linkTo);
+  };
   return (
     <ReviewCardContainer
       isBlock={isBlock}
       border={border}
-      cursorPointer={onClick ? true : false}
-      onClick={() => onClick && onClick()}
+      cursorPointer={linkTo ? true : false}
+      onClick={handleClick}
     >
       {children}
     </ReviewCardContainer>

--- a/src/features/reviews/components/ReviewCard/style.ts
+++ b/src/features/reviews/components/ReviewCard/style.ts
@@ -4,17 +4,23 @@ import styled from "@emotion/styled";
 import { ReviewCardProps } from ".";
 
 export const ReviewCardContainer = styled.article<
-  Pick<ReviewCardProps, "isBlock" | "isBorderTop">
+  Pick<ReviewCardProps, "isBlock" | "isBorderTop"> & { cursorPointer: boolean }
 >`
   border-bottom: 1px solid ${({ theme }) => theme.colors.neutral[10]};
 
-  ${({ theme, isBlock = false, isBorderTop = true }) =>
-    getStyle(theme, isBlock, isBorderTop)}
+  ${({ theme, isBlock = false, isBorderTop = true, cursorPointer }) =>
+    getStyle(theme, isBlock, isBorderTop, cursorPointer)}
 `;
 
-function getStyle(theme: Theme, isBlock: boolean, isBorderTop: boolean) {
+function getStyle(
+  theme: Theme,
+  isBlock: boolean,
+  isBorderTop: boolean,
+  cursorPointer: boolean,
+) {
   let isBlockStyle;
   let isBorderTopStyle;
+  let cursorStyle;
 
   if (isBlock) {
     isBlockStyle = `
@@ -33,8 +39,15 @@ function getStyle(theme: Theme, isBlock: boolean, isBorderTop: boolean) {
     `;
   }
 
+  if (cursorPointer) {
+    cursorStyle = `
+      cursor: pointer;
+    `;
+  }
+
   return css`
     ${isBlockStyle};
     ${isBorderTopStyle};
+    ${cursorStyle}
   `;
 }

--- a/src/features/reviews/components/ReviewCard/style.ts
+++ b/src/features/reviews/components/ReviewCard/style.ts
@@ -7,6 +7,13 @@ export const ReviewCardContainer = styled.article<
   Pick<ReviewCardProps, "isBlock" | "isBorderTop"> & { cursorPointer: boolean }
 >`
   border-bottom: 1px solid ${({ theme }) => theme.colors.neutral[10]};
+  transition: background-color ease 0.1s;
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: #fcfcfc;
+    }
+  }
 
   ${({ theme, isBlock = false, isBorderTop = true, cursorPointer }) =>
     getStyle(theme, isBlock, isBorderTop, cursorPointer)}

--- a/src/features/reviews/components/ReviewCard/style.ts
+++ b/src/features/reviews/components/ReviewCard/style.ts
@@ -1,32 +1,32 @@
 import { css, Theme } from "@emotion/react";
 import styled from "@emotion/styled";
 
-import { ReviewCardProps } from ".";
+import { Border, ReviewCardProps } from ".";
 
 export const ReviewCardContainer = styled.article<
-  Pick<ReviewCardProps, "isBlock" | "isBorderTop"> & { cursorPointer: boolean }
+  Pick<ReviewCardProps, "isBlock" | "border"> & { cursorPointer: boolean }
 >`
   border-bottom: 1px solid ${({ theme }) => theme.colors.neutral[10]};
   transition: background-color ease 0.1s;
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: #fcfcfc;
+      background-color: #fdfdfd;
     }
   }
 
-  ${({ theme, isBlock = false, isBorderTop = true, cursorPointer }) =>
-    getStyle(theme, isBlock, isBorderTop, cursorPointer)}
+  ${({ theme, isBlock = false, border = "bottom", cursorPointer }) =>
+    getStyle(theme, isBlock, border, cursorPointer)}
 `;
 
 function getStyle(
   theme: Theme,
   isBlock: boolean,
-  isBorderTop: boolean,
+  border: Border,
   cursorPointer: boolean,
 ) {
   let isBlockStyle;
-  let isBorderTopStyle;
+  let borderStyle;
   let cursorStyle;
 
   if (isBlock) {
@@ -40,9 +40,13 @@ function getStyle(
     `;
   }
 
-  if (isBorderTop) {
-    isBorderTopStyle = `
+  if (border === "top") {
+    borderStyle = `
       border-top: 1px solid ${theme.colors.neutral[10]};
+    `;
+  } else if (border === "none") {
+    borderStyle = `
+      border: none;
     `;
   }
 
@@ -54,7 +58,7 @@ function getStyle(
 
   return css`
     ${isBlockStyle};
-    ${isBorderTopStyle};
+    ${borderStyle};
     ${cursorStyle}
   `;
 }

--- a/src/features/users/api/mock/profile.json
+++ b/src/features/users/api/mock/profile.json
@@ -1,5 +1,6 @@
 {
   "isMine": true,
+  "memberId": 105510,
   "name": "테스트이름",
   "description": "자기소개입니다",
   "thumbnail": "https://images.unsplash.com/photo-1607604276583-eef5d076aa5f?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1374&q=80",

--- a/src/features/users/hooks/useTabMenu.ts
+++ b/src/features/users/hooks/useTabMenu.ts
@@ -1,11 +1,13 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useRef, useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
-// import useAuth from "@/features/auth/hooks/useAuth";
 import useSortBar from "@/features/users/hooks/useSortBar";
 import { useApi } from "@/hooks/useApi";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
+
+const REVIEW = "review";
+export const BOOKMARK = "bookmark";
 
 export const REVIEW_MENU = "한줄리뷰";
 export const BOOKMARK_MENU = "입덕애니";
@@ -14,9 +16,15 @@ export type MENU = typeof REVIEW_MENU | typeof BOOKMARK_MENU;
 
 export default function useTabMenu(memberId: number) {
   const targetRef = useRef(null);
-  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [selectedMenu, setSelectedMenu] = useState<MENU>(REVIEW_MENU);
-  const handleTabMenuClick = (text: MENU) => setSelectedMenu(text);
+  const handleTabMenuClick = (text: MENU) => {
+    setSelectedMenu(text);
+    text === "한줄리뷰"
+      ? searchParams.set("tab", REVIEW)
+      : searchParams.set("tab", BOOKMARK);
+    setSearchParams(searchParams, { replace: true });
+  };
   const {
     selected: selectedSort,
     SHEET_BUTTONS,
@@ -73,11 +81,12 @@ export default function useTabMenu(memberId: number) {
       ? bookmarks?.pages.length
       : reviews?.pages.length;
 
-  // SideBar 입덕애니 클릭 시, 입덕애니 Menu 선택
+  /** queryString tab === 'bookmark'인 경우, 입덕애니 Menu 선택 */
   useEffect(() => {
-    if (!location.state) return;
-    setSelectedMenu(BOOKMARK_MENU);
-  }, [location.state]);
+    searchParams.get("tab") === BOOKMARK
+      ? setSelectedMenu(BOOKMARK_MENU)
+      : setSelectedMenu(REVIEW_MENU);
+  }, [searchParams]);
 
   return {
     targetRef,

--- a/src/features/users/hooks/useTabMenu.ts
+++ b/src/features/users/hooks/useTabMenu.ts
@@ -2,7 +2,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { useRef, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 
-import useAuth from "@/features/auth/hooks/useAuth";
+// import useAuth from "@/features/auth/hooks/useAuth";
 import useSortBar from "@/features/users/hooks/useSortBar";
 import { useApi } from "@/hooks/useApi";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
@@ -12,7 +12,7 @@ export const BOOKMARK_MENU = "입덕애니";
 
 export type MENU = typeof REVIEW_MENU | typeof BOOKMARK_MENU;
 
-export default function useTabMenu() {
+export default function useTabMenu(memberId: number) {
   const targetRef = useRef(null);
   const location = useLocation();
   const [selectedMenu, setSelectedMenu] = useState<MENU>(REVIEW_MENU);
@@ -22,9 +22,6 @@ export default function useTabMenu() {
     SHEET_BUTTONS,
     handleSortClick,
   } = useSortBar(selectedMenu);
-  const {
-    user: { memberId },
-  } = useAuth();
   const { profile } = useApi();
 
   // bookmark query

--- a/src/features/users/routes/Profile/TabMenu/BookmarkCard.style.ts
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkCard.style.ts
@@ -5,7 +5,16 @@ import { Star } from "@phosphor-icons/react";
 export const BookmarkCardContainer = styled.div`
   display: flex;
   border-bottom: 1px solid ${({ theme }) => theme.colors.neutral[10]};
-  padding: 16px 0;
+  padding: 16px;
+  margin: 0 -16px;
+  cursor: pointer;
+  transition: background-color ease 0.1s;
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: #fdfdfd;
+    }
+  }
 `;
 export const Image = styled.img`
   flex-shrink: 0;

--- a/src/features/users/routes/Profile/TabMenu/BookmarkCard.style.ts
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkCard.style.ts
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { Star } from "@phosphor-icons/react";
+import { Star, Trash } from "@phosphor-icons/react";
 
 export const BookmarkCardContainer = styled.div`
   display: flex;
@@ -29,6 +29,7 @@ export const InfoContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  width: 100%;
 `;
 
 export const Title = styled.h4`
@@ -85,7 +86,52 @@ export const MyScore = styled.span`
   color: ${({ theme }) => theme.colors.primary[60]};
 `;
 
+export const BottomContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  /* & > svg {
+    color: ${({ theme }) => theme.colors.neutral[40]};
+
+    border-radius: 50%;
+
+    &:hover {
+      background-color: ${({ theme }) => theme.colors.neutral[10]};
+      color: ${({ theme }) => theme.colors.neutral[50]};
+    }
+  } */
+`;
+
 export const CreatedDate = styled.time`
   ${({ theme }) => theme.typo["body-3-r"]}
   color: ${({ theme }) => theme.colors.neutral[40]}
+`;
+
+export const TrashIconContainer = styled.div`
+  position: relative;
+  right: -8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  padding: 8px;
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${({ theme }) => theme.colors.neutral[10]};
+
+      & > svg {
+        color: ${({ theme }) => theme.colors.neutral[50]};
+      }
+    }
+  }
+
+  &:active {
+    background-color: ${({ theme }) => theme.colors.neutral[10]};
+  }
+`;
+
+export const TrashIcon = styled(Trash)`
+  color: ${({ theme }) => theme.colors.neutral[40]};
 `;

--- a/src/features/users/routes/Profile/TabMenu/BookmarkCard.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkCard.tsx
@@ -1,3 +1,5 @@
+import { AnimatePresence } from "framer-motion";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import {
@@ -15,6 +17,7 @@ import {
   TrashIcon,
   TrashIconContainer,
 } from "./BookmarkCard.style";
+import BookmarkDelteModal from "./BookmarkDeleteModal";
 
 interface BookmarkCardProps {
   bookmark: Bookmark;
@@ -22,39 +25,56 @@ interface BookmarkCardProps {
 }
 
 export default function BookmarkCard({ bookmark, isMine }: BookmarkCardProps) {
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const toggleDeleteModal = () => setIsDeleteModalOpen((prev) => !prev);
+  const handleDeleteModalToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    toggleDeleteModal();
+  };
   const navigate = useNavigate();
   const handleLinkToAnime = () => navigate(`/animes/${bookmark.animeId}`);
 
   return (
-    <BookmarkCardContainer onClick={handleLinkToAnime}>
-      <Image src={bookmark.thumbnail} alt={bookmark.title} />
-      <InfoContainer>
-        <Title>{bookmark.title}</Title>
-        <div>
-          <RatingContainer>
-            <ScoreContainer>
-              <StarIcon size={13} weight="fill" color="yellow" />
-              <Score>평균 {bookmark.avgScore / 2}</Score>
-            </ScoreContainer>
-            <ScoreContainer>
-              {bookmark.myScore >= 0 && (
-                <>
-                  <StarIcon size={13} weight="fill" color="blue" />
-                  <MyScore>내 평점 {bookmark.myScore / 2}</MyScore>
-                </>
+    <>
+      <BookmarkCardContainer onClick={handleLinkToAnime}>
+        <Image src={bookmark.thumbnail} alt={bookmark.title} />
+        <InfoContainer>
+          <Title>{bookmark.title}</Title>
+          <div>
+            <RatingContainer>
+              <ScoreContainer>
+                <StarIcon size={13} weight="fill" color="yellow" />
+                <Score>평균 {bookmark.avgScore / 2}</Score>
+              </ScoreContainer>
+              <ScoreContainer>
+                {bookmark.myScore >= 0 && (
+                  <>
+                    <StarIcon size={13} weight="fill" color="blue" />
+                    <MyScore>내 평점 {bookmark.myScore / 2}</MyScore>
+                  </>
+                )}
+                {bookmark.myScore < 0 && <Score>평가전</Score>}
+              </ScoreContainer>
+            </RatingContainer>
+            <BottomContainer>
+              <CreatedDate>{dateWithDots(bookmark.createdAt)}</CreatedDate>
+              {isMine && (
+                <TrashIconContainer onClick={(e) => handleDeleteModalToggle(e)}>
+                  {<TrashIcon size={18} />}
+                </TrashIconContainer>
               )}
-              {bookmark.myScore < 0 && <Score>평가전</Score>}
-            </ScoreContainer>
-          </RatingContainer>
-          <BottomContainer>
-            <CreatedDate>{dateWithDots(bookmark.createdAt)}</CreatedDate>
-            <TrashIconContainer onClick={(e) => e.stopPropagation()}>
-              {<TrashIcon size={18} />}
-            </TrashIconContainer>
-          </BottomContainer>
-        </div>
-      </InfoContainer>
-    </BookmarkCardContainer>
+            </BottomContainer>
+          </div>
+        </InfoContainer>
+      </BookmarkCardContainer>
+      {isMine && (
+        <AnimatePresence>
+          {isDeleteModalOpen && (
+            <BookmarkDelteModal onClose={toggleDeleteModal} />
+          )}
+        </AnimatePresence>
+      )}
+    </>
   );
 }
 

--- a/src/features/users/routes/Profile/TabMenu/BookmarkCard.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkCard.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 
 import {
   BookmarkCardContainer,
+  BottomContainer,
   CreatedDate,
   Image,
   InfoContainer,
@@ -11,13 +12,16 @@ import {
   ScoreContainer,
   StarIcon,
   Title,
+  TrashIcon,
+  TrashIconContainer,
 } from "./BookmarkCard.style";
 
 interface BookmarkCardProps {
   bookmark: Bookmark;
+  isMine: boolean;
 }
 
-export default function BookmarkCard({ bookmark }: BookmarkCardProps) {
+export default function BookmarkCard({ bookmark, isMine }: BookmarkCardProps) {
   const navigate = useNavigate();
   const handleLinkToAnime = () => navigate(`/animes/${bookmark.animeId}`);
 
@@ -42,7 +46,12 @@ export default function BookmarkCard({ bookmark }: BookmarkCardProps) {
               {bookmark.myScore < 0 && <Score>평가전</Score>}
             </ScoreContainer>
           </RatingContainer>
-          <CreatedDate>{dateWithDots(bookmark.createdAt)}</CreatedDate>
+          <BottomContainer>
+            <CreatedDate>{dateWithDots(bookmark.createdAt)}</CreatedDate>
+            <TrashIconContainer onClick={(e) => e.stopPropagation()}>
+              {<TrashIcon size={18} />}
+            </TrashIconContainer>
+          </BottomContainer>
         </div>
       </InfoContainer>
     </BookmarkCardContainer>

--- a/src/features/users/routes/Profile/TabMenu/BookmarkCard.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkCard.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from "react-router-dom";
+
 import {
   BookmarkCardContainer,
   CreatedDate,
@@ -16,8 +18,11 @@ interface BookmarkCardProps {
 }
 
 export default function BookmarkCard({ bookmark }: BookmarkCardProps) {
+  const navigate = useNavigate();
+  const handleLinkToAnime = () => navigate(`/animes/${bookmark.animeId}`);
+
   return (
-    <BookmarkCardContainer>
+    <BookmarkCardContainer onClick={handleLinkToAnime}>
       <Image src={bookmark.thumbnail} alt={bookmark.title} />
       <InfoContainer>
         <Title>{bookmark.title}</Title>

--- a/src/features/users/routes/Profile/TabMenu/BookmarkDeleteModal.style.ts
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkDeleteModal.style.ts
@@ -1,0 +1,18 @@
+import styled from "@emotion/styled";
+import { X } from "@phosphor-icons/react";
+
+export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+`;
+export const CloseButton = styled(X)`
+  position: relative;
+  right: -8px;
+  align-self: flex-end;
+  margin-bottom: 16px;
+`;
+export const Title = styled.h3`
+  ${({ theme }) => theme.typo["body-3-r"]}
+`;

--- a/src/features/users/routes/Profile/TabMenu/BookmarkDeleteModal.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkDeleteModal.tsx
@@ -1,0 +1,53 @@
+import { X } from "@phosphor-icons/react";
+
+import Button from "@/components/Button";
+import Modal from "@/components/Modal";
+
+import {
+  CloseButton,
+  ContentContainer,
+  Title,
+} from "./BookmarkDeleteModal.style";
+
+interface BookmarkDelteModalProps {
+  onClose: () => void;
+}
+
+export default function BookmarkDelteModal({
+  onClose,
+}: BookmarkDelteModalProps) {
+  return (
+    <>
+      <Modal onClose={onClose} size="sm">
+        <Modal.Content>
+          <ContentContainer>
+            <CloseButton type="button" onClick={onClose}>
+              <X size={24} />
+            </CloseButton>
+            <Title>애니를 삭제하시겠습니까?</Title>
+          </ContentContainer>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button
+            variant="text"
+            name="닫기"
+            color="neutral"
+            isBlock
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            variant="solid"
+            name="삭제"
+            color="warn"
+            isBlock
+            onClick={() => {}}
+          >
+            삭제
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    </>
+  );
+}

--- a/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
@@ -14,6 +14,7 @@ export default function BookmarkList({ isMine, list }: BookmarkListProps) {
           message="작성한 리뷰가 없어요. 리뷰를 작성해 보세요."
           buttonText="리뷰 작성하기"
           linkTo="/animes"
+          isMine={isMine}
         />
       )}
       {list.map((bookmark) => (

--- a/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
@@ -1,4 +1,5 @@
 import BookmarkCard from "./BookmarkCard";
+import EmptyList from "./EmptyList";
 
 interface BookmarkListProps {
   list: Bookmark[];
@@ -7,6 +8,13 @@ interface BookmarkListProps {
 export default function BookmarkList({ list }: BookmarkListProps) {
   return (
     <>
+      {list.length === 0 && (
+        <EmptyList
+          message="작성한 리뷰가 없어요. 리뷰를 작성해 보세요."
+          buttonText="리뷰 작성하기"
+          linkTo="/animes"
+        />
+      )}
       {list.map((bookmark) => (
         <BookmarkCard key={bookmark.animeId} bookmark={bookmark} />
       ))}

--- a/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
@@ -11,7 +11,9 @@ export default function BookmarkList({ isMine, list }: BookmarkListProps) {
     <>
       {list.length === 0 && (
         <EmptyList
-          message="입덕한 애니가 없어요. 애니를 추가해 보세요"
+          message={`입덕한 애니가 없어요.${
+            isMine ? " 애니를 추가해 보세요" : ""
+          }`}
           buttonText="애니 추가하러 가기"
           linkTo="/animes"
           isMine={isMine}

--- a/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
@@ -11,8 +11,8 @@ export default function BookmarkList({ isMine, list }: BookmarkListProps) {
     <>
       {list.length === 0 && (
         <EmptyList
-          message="작성한 리뷰가 없어요. 리뷰를 작성해 보세요."
-          buttonText="리뷰 작성하기"
+          message="입덕한 애니가 없어요. 애니를 추가해 보세요"
+          buttonText="애니 추가하러 가기"
           linkTo="/animes"
           isMine={isMine}
         />

--- a/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
@@ -2,10 +2,11 @@ import BookmarkCard from "./BookmarkCard";
 import EmptyList from "./EmptyList";
 
 interface BookmarkListProps {
+  isMine: boolean;
   list: Bookmark[];
 }
 
-export default function BookmarkList({ list }: BookmarkListProps) {
+export default function BookmarkList({ isMine, list }: BookmarkListProps) {
   return (
     <>
       {list.length === 0 && (
@@ -16,7 +17,11 @@ export default function BookmarkList({ list }: BookmarkListProps) {
         />
       )}
       {list.map((bookmark) => (
-        <BookmarkCard key={bookmark.animeId} bookmark={bookmark} />
+        <BookmarkCard
+          key={bookmark.animeId}
+          bookmark={bookmark}
+          isMine={isMine}
+        />
       ))}
     </>
   );

--- a/src/features/users/routes/Profile/TabMenu/EmptyList.style.ts
+++ b/src/features/users/routes/Profile/TabMenu/EmptyList.style.ts
@@ -1,0 +1,26 @@
+import styled from "@emotion/styled";
+
+import Button from "@/components/Button";
+
+export const EmptyListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 52px;
+`;
+
+export const EmptyImage = styled.img`
+  width: 107px;
+  height: 107px;
+  margin-bottom: 24px;
+`;
+
+export const Message = styled.span`
+  ${({ theme }) => theme.typo["body-2-r"]}
+  color: ${({ theme }) => theme.colors.neutral[40]};
+  margin-bottom: 16px;
+`;
+
+export const EmptyListButton = styled(Button)`
+  width: 202px;
+`;

--- a/src/features/users/routes/Profile/TabMenu/EmptyList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/EmptyList.tsx
@@ -1,0 +1,32 @@
+import { useNavigate } from "react-router-dom";
+
+import {
+  EmptyImage,
+  EmptyListButton,
+  EmptyListContainer,
+  Message,
+} from "./EmptyList.style";
+
+interface EmptyListProps {
+  message: string;
+  buttonText: string;
+  linkTo: string;
+}
+
+export default function EmptyList({
+  message,
+  buttonText,
+  linkTo,
+}: EmptyListProps) {
+  const navigate = useNavigate();
+  const handleClick = () => navigate(linkTo);
+  return (
+    <EmptyListContainer>
+      <EmptyImage src="/logo/logo-empty.png" alt="등록된 아이템이 없어요." />
+      <Message>{message}</Message>
+      <EmptyListButton name={buttonText} size="lg" onClick={handleClick}>
+        {buttonText}
+      </EmptyListButton>
+    </EmptyListContainer>
+  );
+}

--- a/src/features/users/routes/Profile/TabMenu/EmptyList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/EmptyList.tsx
@@ -11,12 +11,14 @@ interface EmptyListProps {
   message: string;
   buttonText: string;
   linkTo: string;
+  isMine: boolean;
 }
 
 export default function EmptyList({
   message,
   buttonText,
   linkTo,
+  isMine,
 }: EmptyListProps) {
   const navigate = useNavigate();
   const handleClick = () => navigate(linkTo);
@@ -24,9 +26,11 @@ export default function EmptyList({
     <EmptyListContainer>
       <EmptyImage src="/logo/logo-empty.png" alt="등록된 아이템이 없어요." />
       <Message>{message}</Message>
-      <EmptyListButton name={buttonText} size="lg" onClick={handleClick}>
-        {buttonText}
-      </EmptyListButton>
+      {isMine && (
+        <EmptyListButton name={buttonText} size="lg" onClick={handleClick}>
+          {buttonText}
+        </EmptyListButton>
+      )}
     </EmptyListContainer>
   );
 }

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from "react-router-dom";
+
 import ReviewCard from "@/features/reviews/components/ReviewCard";
 
 import EmptyList from "./EmptyList";
@@ -8,6 +10,8 @@ interface ReviewListProps {
 }
 
 export default function ReviewList({ isMine, list }: ReviewListProps) {
+  const navigate = useNavigate();
+  const handleClick = (to: string) => navigate(to);
   return (
     <>
       {list.length === 0 && (
@@ -18,7 +22,12 @@ export default function ReviewList({ isMine, list }: ReviewListProps) {
         />
       )}
       {list.map((review) => (
-        <ReviewCard key={review.anime.animeId} isBlock isBorderTop={false}>
+        <ReviewCard
+          key={review.anime.animeId}
+          isBlock
+          isBorderTop={false}
+          onClick={() => handleClick(`/animes/${review.anime.animeId}`)}
+        >
           <ReviewCard.Anime anime={review.anime} />
           <ReviewCard.Comment
             text={review.comment}

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -25,7 +25,6 @@ export default function ReviewList({ isMine, list }: ReviewListProps) {
         <ReviewCard
           key={review.anime.animeId}
           isBlock
-          isBorderTop={false}
           onClick={() => handleClick(`/animes/${review.anime.animeId}`)}
         >
           <ReviewCard.Anime anime={review.anime} />

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -1,5 +1,3 @@
-import { useNavigate } from "react-router-dom";
-
 import ReviewCard from "@/features/reviews/components/ReviewCard";
 
 import EmptyList from "./EmptyList";
@@ -10,8 +8,6 @@ interface ReviewListProps {
 }
 
 export default function ReviewList({ isMine, list }: ReviewListProps) {
-  const navigate = useNavigate();
-  const handleClick = (to: string) => navigate(to);
   return (
     <>
       {list.length === 0 && (
@@ -25,7 +21,7 @@ export default function ReviewList({ isMine, list }: ReviewListProps) {
         <ReviewCard
           key={review.anime.animeId}
           isBlock
-          onClick={() => handleClick(`/animes/${review.anime.animeId}`)}
+          linkTo={`/animes/${review.anime.animeId}`}
         >
           <ReviewCard.Anime anime={review.anime} />
           <ReviewCard.Comment

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -12,8 +12,8 @@ export default function ReviewList({ isMine, list }: ReviewListProps) {
     <>
       {list.length === 0 && (
         <EmptyList
-          message="입덕한 애니가 없어요. 애니를 추가해 보세요"
-          buttonText="애니 추가하러 가기"
+          message="작성한 리뷰가 없어요. 리뷰를 작성해 보세요."
+          buttonText="리뷰 작성하기"
           linkTo="/animes"
           isMine={isMine}
         />

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -1,5 +1,7 @@
 import ReviewCard from "@/features/reviews/components/ReviewCard";
 
+import EmptyList from "./EmptyList";
+
 interface ReviewListProps {
   isMine: boolean;
   list: Review[];
@@ -8,6 +10,13 @@ interface ReviewListProps {
 export default function ReviewList({ isMine, list }: ReviewListProps) {
   return (
     <>
+      {list.length === 0 && (
+        <EmptyList
+          message="입덕한 애니가 없어요. 애니를 추가해 보세요"
+          buttonText="애니 추가하러 가기"
+          linkTo="/animes"
+        />
+      )}
       {list.map((review) => (
         <ReviewCard key={review.anime.animeId} isBlock isBorderTop={false}>
           <ReviewCard.Anime anime={review.anime} />

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -12,7 +12,9 @@ export default function ReviewList({ isMine, list }: ReviewListProps) {
     <>
       {list.length === 0 && (
         <EmptyList
-          message="작성한 리뷰가 없어요. 리뷰를 작성해 보세요."
+          message={`작성한 리뷰가 없어요.${
+            isMine ? " 리뷰를 작성해 보세요" : ""
+          } `}
           buttonText="리뷰 작성하기"
           linkTo="/animes"
           isMine={isMine}

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -15,6 +15,7 @@ export default function ReviewList({ isMine, list }: ReviewListProps) {
           message="입덕한 애니가 없어요. 애니를 추가해 보세요"
           buttonText="애니 추가하러 가기"
           linkTo="/animes"
+          isMine={isMine}
         />
       )}
       {list.map((review) => (

--- a/src/features/users/routes/Profile/TabMenu/index.tsx
+++ b/src/features/users/routes/Profile/TabMenu/index.tsx
@@ -17,9 +17,10 @@ const TAB_BUTTONS = [
 
 interface TabMenuProps {
   isMine: boolean;
+  memberId: number;
 }
 
-export default function TabMenu({ isMine }: TabMenuProps) {
+export default function TabMenu({ isMine, memberId }: TabMenuProps) {
   const {
     targetRef,
     selectedMenu,
@@ -32,7 +33,7 @@ export default function TabMenu({ isMine }: TabMenuProps) {
     handleTabMenuClick,
     SHEET_BUTTONS,
     handleSortClick,
-  } = useTabMenu();
+  } = useTabMenu(memberId);
 
   return (
     <>

--- a/src/features/users/routes/Profile/TabMenu/index.tsx
+++ b/src/features/users/routes/Profile/TabMenu/index.tsx
@@ -61,7 +61,7 @@ export default function TabMenu({ isMine, memberId }: TabMenuProps) {
           <ReviewList isMine={isMine} list={reviews?.pages ?? []} />
         )}
         {selectedMenu === "입덕애니" && (
-          <BookmarkList list={bookmarks?.pages ?? []} />
+          <BookmarkList isMine={isMine} list={bookmarks?.pages ?? []} />
         )}
 
         <Target ref={targetRef} />

--- a/src/features/users/routes/Profile/index.tsx
+++ b/src/features/users/routes/Profile/index.tsx
@@ -48,7 +48,10 @@ export default function Profile() {
           <ProfileContainer>
             <AboutMe profile={userProfile} />
             <ErrorBoundary onReset={reset}>
-              <TabMenu isMine={userProfile.isMine} />
+              <TabMenu
+                isMine={userProfile.isMine}
+                memberId={userProfile.memberId}
+              />
             </ErrorBoundary>
           </ProfileContainer>
         </>

--- a/src/routes/privateRoutes.tsx
+++ b/src/routes/privateRoutes.tsx
@@ -9,7 +9,7 @@ const Profile = lazy(() => import("@/features/users/routes/Profile"));
 const ProfileEdit = lazy(() => import("@/features/users/routes/Edit"));
 
 function PrivateRoute({ children }: PropsWithChildren) {
-  const { isLoggedIn, fetchUser } = useAuth();
+  const { fetchUser } = useAuth();
   const { localUser } = useLocalUser();
   const navigate = useNavigate();
 
@@ -27,8 +27,6 @@ function PrivateRoute({ children }: PropsWithChildren) {
     };
     handleAuth();
   }, []);
-
-  if (!isLoggedIn) return null;
 
   return children;
 }

--- a/src/types/business.d.ts
+++ b/src/types/business.d.ts
@@ -17,6 +17,7 @@ declare interface User extends BaseTimeEntity {
 }
 
 declare interface Profile {
+  memberId: number;
   name: string;
   description: string;
   backgroundImage: string;


### PR DESCRIPTION
## 📝 개요
프로필 페이지 변경사항 적용


## 🚀 변경사항
1. EmptyList 컴포넌트
   - 한줄리뷰, 입덕애니가 한개도 없을때 보여질 UI
   - 버튼 클릭 시 `/animes` 페이지로 이동
   - ![image](https://github.com/oduck-team/oduck-client/assets/115006670/3c2a5e07-d9ee-41a2-8869-e30d44013975)

2. 리뷰카드, 북마크카드
   - 카드 클릭 시, 해당 애니 페이지로 이동
   - hover 스타일 적용

3. 한줄리뷰, 입덕애니 Tab 클릭 시, query string을 가지도록 변경

4. 북마크 삭제 버튼, 모달 퍼블리싱
  - ![image](https://github.com/oduck-team/oduck-client/assets/115006670/0b1e791f-30ef-4e3a-b975-06f5f652fbad)


## 🔗 관련 이슈
#240


## ➕ 기타
