### PR TITLE
feat: 애니 상세페이지 리뷰 목록 스타일 수정 및 스켈레톤 추가

### DIFF
--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -5,6 +5,8 @@ export interface SkeletonProps {
   h?: number | "full";
   /** 스켈레톤 넓이 @default 24 */
   w?: number | "full";
+  /** 스켈레톤 넓이 단위 @default px */
+  wUnit?: "%" | "px";
   /** 스켈레톤 모서리의 둥근 정도 @default 4 */
   borderRadius?: number | "full";
 }
@@ -12,12 +14,14 @@ export interface SkeletonProps {
 export default function Skeleton({
   h = 24,
   w = 24,
+  wUnit = "px",
   borderRadius = 4,
 }: SkeletonProps) {
   return (
     <SkeletonContainer
       h={h}
       w={w}
+      wUnit={wUnit}
       borderRadius={borderRadius === "full" ? 999 : borderRadius}
     />
   );

--- a/src/components/Skeleton/style.ts
+++ b/src/components/Skeleton/style.ts
@@ -11,7 +11,8 @@ const pulse = keyframes`
 
 export const SkeletonContainer = styled.div<SkeletonProps>`
   height: ${({ h }) => (h === "full" ? "100%" : `${h}px`)};
-  width: ${({ w }) => (w === "full" ? "100%" : `${w}px`)};
+  width: ${({ w, wUnit }) =>
+    w === "full" ? "100%" : wUnit === "px" ? `${w}px` : `${w}%`};
   border-radius: ${({ borderRadius }) => borderRadius}px;
   background-color: ${({ theme }) => theme.colors.neutral["20"]};
   animation: ${pulse} 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;

--- a/src/features/animes/routes/Detail/LoadingReviews/index.tsx
+++ b/src/features/animes/routes/Detail/LoadingReviews/index.tsx
@@ -1,0 +1,22 @@
+import { v4 as uuid } from "uuid";
+
+import Skeleton from "@/components/Skeleton";
+
+import { ReviewSkeleton } from "./style";
+
+export default function LoadingReviews() {
+  return (
+    <ul>
+      {Array.from({ length: 7 }, () => (
+        <ReviewSkeleton aria-busy="true" key={uuid()}>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <Skeleton w={100} h={16} />
+            <Skeleton w={24} h={24} borderRadius="full" />
+          </div>
+          <Skeleton w={75} wUnit="%" h={18} />
+          <Skeleton w={60} wUnit="%" h={18} />
+        </ReviewSkeleton>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/animes/routes/Detail/LoadingReviews/style.ts
+++ b/src/features/animes/routes/Detail/LoadingReviews/style.ts
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+
+export const ReviewSkeleton = styled.li`
+  padding: 16px 10px 20px;
+
+  & > div:nth-child(2) {
+    margin: 8px 0 4px;
+  }
+
+  & > div:nth-child(3) {
+    margin-bottom: 6px;
+  }
+
+  &:first-of-type {
+    border-top: 1px solid ${({ theme }) => theme.colors.neutral[10]};
+  }
+
+  border-bottom: 1px solid ${({ theme }) => theme.colors.neutral[10]};
+`;

--- a/src/features/animes/routes/Detail/Reviews/index.tsx
+++ b/src/features/animes/routes/Detail/Reviews/index.tsx
@@ -39,31 +39,31 @@ export default function Reviews({
           </li>
         ))}
       </ul>
-
-      <ul>
-        {reviews.map((review, i) => (
-          <li key={review.reviewId}>
-            <ReviewCard border={i === 0 ? "top" : "bottom"}>
-              <ReviewCard.UserRating
-                user={{ name: review.name, thumbnail: review.thumbnail }}
-                rating={review.score}
-              />
-              <ReviewCard.Comment
-                text={review.content}
-                textSize="sm"
-                isSpoiler={review.isSpoiler}
-              />
-              <ReviewCard.ActionBar
-                isMine={review.isMine}
-                isLiked={review.isLiked}
-                likeCount={review.likeCount}
-                include="time"
-                createdAt={review.createdAt}
-              />
-            </ReviewCard>
-          </li>
-        ))}
-      </ul>
+      {reviews.length !== 0 && (
+        <ul>
+          {reviews.map((review, i) => (
+            <li key={review.reviewId}>
+              <ReviewCard border={i === 0 ? "top" : "bottom"}>
+                <ReviewCard.UserRating
+                  user={{ name: review.name, thumbnail: review.thumbnail }}
+                  rating={review.score}
+                />
+                <ReviewCard.Comment
+                  text={review.content}
+                  textSize="sm"
+                  isSpoiler={review.isSpoiler}
+                />
+                <ReviewCard.ActionBar
+                  isMine={review.isMine}
+                  isLiked={review.isLiked}
+                  likeCount={review.likeCount}
+                  createdAt={review.createdAt}
+                />
+              </ReviewCard>
+            </li>
+          ))}
+        </ul>
+      )}
     </Section>
   );
 }

--- a/src/features/animes/routes/Detail/Reviews/index.tsx
+++ b/src/features/animes/routes/Detail/Reviews/index.tsx
@@ -3,10 +3,13 @@ import { ReviewInfo } from "@/features/reviews/api/review";
 import ReviewCard from "@/features/reviews/components/ReviewCard";
 import { ReviewSortOption } from "@/features/reviews/hook/useGetAnimeReviews";
 
+import LoadingReviews from "../LoadingReviews";
+
 import { Section, TotalReviews } from "./style";
 
 interface Props {
   reviews: ReviewInfo[];
+  isLoading: boolean;
   totalReviewCount: number;
   handleChipClick: (i: number) => void;
   sortOptions: ReviewSortOption[];
@@ -15,6 +18,7 @@ interface Props {
 
 export default function Reviews({
   reviews,
+  isLoading,
   totalReviewCount,
   sortOptions,
   selectedOption,
@@ -39,7 +43,9 @@ export default function Reviews({
           </li>
         ))}
       </ul>
-      {reviews.length !== 0 && (
+      {isLoading && <LoadingReviews />}
+      {/* { TODO: 리뷰가 0개일 때 디자인 적용 } */}
+      {!isLoading && reviews.length !== 0 && (
         <ul>
           {reviews.map((review, i) => (
             <li key={review.reviewId}>

--- a/src/features/animes/routes/Detail/Reviews/style.ts
+++ b/src/features/animes/routes/Detail/Reviews/style.ts
@@ -8,6 +8,11 @@ export const Section = styled(SectionContainer)`
     gap: 4px;
     padding-bottom: 16px;
   }
+
+  li > article {
+    padding-left: 8px;
+    padding-right: 10px;
+  }
 `;
 
 export const TotalReviews = styled.p`

--- a/src/features/animes/routes/Detail/index.tsx
+++ b/src/features/animes/routes/Detail/index.tsx
@@ -51,6 +51,7 @@ export default function AnimeDetail() {
         {/* 리뷰 목록 */}
         <Reviews
           reviews={reviews?.pages ?? []}
+          isLoading={isLoading}
           totalReviewCount={anime.reviewCount}
           sortOptions={SORT_OPTION}
           selectedOption={selectedSortOption}

--- a/src/features/common/routes/Home/RecentReview/index.tsx
+++ b/src/features/common/routes/Home/RecentReview/index.tsx
@@ -40,7 +40,6 @@ export default function RecentReview() {
             isSpoiler={REVIEW_MOCK_DATA.isSpoiler}
           />
           <ReviewCard.ActionBar
-            include="time"
             createdAt={REVIEW_MOCK_DATA.createdAt}
             isMine={false} // TODO: isMine 판별
             isLiked={REVIEW_MOCK_DATA.isLiked}

--- a/src/features/reviews/api/review.ts
+++ b/src/features/reviews/api/review.ts
@@ -2,34 +2,26 @@ import { get, post } from "@/libs/api";
 
 import { ReviewSortOption } from "../hook/useGetAnimeReviews";
 
-export interface ReviewInfo {
+export type ReviewInfo = Omit<Review, "anime"> & {
   reviewId: number;
   animeId: number;
-  name: string;
   thumbnail: string;
   score: number;
-  content: string;
-  isSpoiler: boolean;
-  isLiked: boolean;
-  likeCount: number;
   isMine: boolean;
-  createdAt: string;
-}
+};
 
-export interface AddReviewDto {
-  name: string;
+export type AddReviewDto = Pick<Review, "name" | "content"> & {
   animeId: number;
-  isSpoiler: boolean;
-  content: string;
-}
+  hasSpoiler: boolean;
+};
 
 export default class ReviewApi {
-  /** @description 리뷰 작성 요청*/
+  /** @description 리뷰 작성 요청 */
   async addReview(review: AddReviewDto): Promise<void> {
     return post("/short-reviews", review);
   }
 
-  /** @description 한 애니의 리뷰 목록 요청*/
+  /** @description 한 애니의 리뷰 목록 요청 */
   async getAnimeReviews(
     animeId: number,
     pageParam: string,

--- a/src/features/reviews/components/ReviewCard/ActionBar.style.ts
+++ b/src/features/reviews/components/ReviewCard/ActionBar.style.ts
@@ -1,46 +1,15 @@
-import { SerializedStyles, css } from "@emotion/react";
 import styled from "@emotion/styled";
 
-import { ActionBarProps, Include } from "./ActionBar";
-
-export const ActionBarContainer = styled.div<Pick<ActionBarProps, "include">>`
+export const ActionBarContainer = styled.div`
   ${({ theme }) => theme.typo["body-3-r"]}
   color: #adaeb8;
-
-  ${({ include = "common" }) => getActionBarContainerStyle(include)};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 10px;
 `;
 
-export const ButtonContainer = styled.div<Pick<ActionBarProps, "include">>`
-  ${({ include = "common" }) => getButtonContainerStyle(include)}
+export const ButtonContainer = styled.div`
+  display: flex;
+  gap: 8px;
 `;
-
-function getActionBarContainerStyle(include: Include) {
-  const styles: Record<Include, SerializedStyles> = {
-    time: css`
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding-top: 8px;
-    `,
-    common: css`
-      padding-top: 16px;
-    `,
-  };
-
-  return styles[include];
-}
-
-function getButtonContainerStyle(include: Include) {
-  const styles: Record<Include, SerializedStyles> = {
-    time: css`
-      display: flex;
-      gap: 8px;
-    `,
-    common: css`
-      display: flex;
-      justify-content: space-between;
-    `,
-  };
-
-  return styles[include];
-}

--- a/src/features/reviews/components/ReviewCard/ActionBar.tsx
+++ b/src/features/reviews/components/ReviewCard/ActionBar.tsx
@@ -4,13 +4,10 @@ import { ActionBarContainer, ButtonContainer } from "./ActionBar.style";
 import ReviewLikeButton from "./ReviewLikeButton";
 import ReviewMoreButton from "./ReviewMoreButton";
 
-export type Include = "time" | "common";
-
 export interface ActionBarProps {
   isMine: boolean;
   isLiked: boolean;
   likeCount: number;
-  include?: Include;
   createdAt?: string;
   isTimeAgo?: boolean;
 }
@@ -18,16 +15,15 @@ export default function ActionBar({
   isMine,
   isLiked,
   likeCount,
-  include = "common",
   createdAt,
   isTimeAgo,
 }: ActionBarProps) {
   const date = isTimeAgo ? timeAgo(createdAt) : dateWithDots(createdAt);
 
   return (
-    <ActionBarContainer include={include}>
-      {include === "time" && date && <time>{date}</time>}
-      <ButtonContainer include={include} onClick={(e) => e.stopPropagation()}>
+    <ActionBarContainer>
+      {date && <time>{date}</time>}
+      <ButtonContainer onClick={(e) => e.stopPropagation()}>
         <ReviewLikeButton
           isLiked={isLiked}
           count={compactNumber(likeCount, "ko-KR")}

--- a/src/features/reviews/components/ReviewCard/SpoilerComment.style.ts
+++ b/src/features/reviews/components/ReviewCard/SpoilerComment.style.ts
@@ -7,6 +7,7 @@ export const SpoilerCommentContainer = styled.div`
   height: 56px;
   width: 100%;
   padding: 0 16px;
+  margin: 12px 0 6px;
   border: none;
   border-radius: 10px;
   background-color: ${({ theme }) => theme.colors.neutral["05"]};

--- a/src/features/reviews/components/ReviewCard/UserRating.style.ts
+++ b/src/features/reviews/components/ReviewCard/UserRating.style.ts
@@ -4,7 +4,7 @@ export const CreatorContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 12px;
+  margin-bottom: 4px;
 `;
 
 export const Username = styled.span`

--- a/src/features/reviews/components/ReviewCard/style.ts
+++ b/src/features/reviews/components/ReviewCard/style.ts
@@ -32,11 +32,11 @@ function getStyle(
   if (isBlock) {
     isBlockStyle = `
       margin: 0 -16px;
-      padding: 16px;
+      padding: 16px 16px 14px;
     `;
   } else {
     isBlockStyle = `
-      padding: 16px 0;
+      padding: 16px 0 14px;
     `;
   }
 

--- a/src/features/reviews/hook/useReviewForm.tsx
+++ b/src/features/reviews/hook/useReviewForm.tsx
@@ -75,7 +75,7 @@ export default function useReviewForm(
       {
         name,
         animeId,
-        isSpoiler: form.isSpoiler,
+        hasSpoiler: form.isSpoiler,
         content: form.content,
       },
       {

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -32,7 +32,6 @@ export default function ReviewList({ isMine, list }: ReviewListProps) {
             isSpoiler={review.isSpoiler}
           />
           <ReviewCard.ActionBar
-            include="time"
             createdAt={review.createdAt}
             isTimeAgo={false}
             isMine={isMine}


### PR DESCRIPTION
## 📝 개요

figma에서 리뷰 스타일 수정된 부분 반영했습니다. 리뷰 목록 스켈레톤을 추가했습니다.

https://github.com/oduck-team/oduck-client/assets/80813703/b90c8be6-4b52-451d-a2f7-904f959fd144


## 🚀 변경사항

- Review api 요청/응답 타입을 수정하였습니다. #272 
- ReviewCard에서 `include` props가 제거되었습니다.
- 리뷰 목록 스켈레톤을 구현하면서 스켈레톤 컴포넌트가 가로 길이의 경우에는 반응형으로 %단위도 적용할 수 있으면 좋을 것 같아서 width unit props를 추가했습니다.

```typescript
<Skeleton w={75} wUnit="%" h={18} />
```

## 🔗 관련 이슈

#233 #234

## ➕ 기타

코드 리뷰 부탁드립니다!

<br/>