### PR TITLE
feat: 관리자 애니 목록 페이지네이션

### DIFF
--- a/src/admins/features/animes/api/AdminAnimeApi.ts
+++ b/src/admins/features/animes/api/AdminAnimeApi.ts
@@ -1,6 +1,6 @@
 import { ADMIN_BASE_URL } from "@/admins/constants/config";
 import AnimeApi from "@/features/animes/api/AnimeApi";
-import { post } from "@/libs/api";
+import { del, get, post } from "@/libs/api";
 
 export interface CreateAnimeDto {
   /** 시리즈 id */
@@ -35,8 +35,63 @@ export interface CreateAnimeDto {
   genreIds: number[];
 }
 
+export interface GetAnimePagetQuery {
+  /** 검색어 1-50자 */
+  query: string;
+
+  /** 검색 타입 */
+  queryType: "TITLE" | "SERIES";
+
+  page: number;
+
+  /** 요청당 최대 출력 개수 */
+  size: number;
+
+  direction: "ASC" | "DESC";
+
+  statuses?: AnimeStatus[];
+
+  years?: number;
+}
+
+export type PageAnimeResponse = Page<{
+  id: number;
+  title: string;
+  thumbnail: string;
+  year: number;
+  quarter: AnimeQuarter;
+  isReleased: boolean;
+  status: AnimeStatus;
+  seriesId: number;
+  seriesTitle: string;
+  bookmarkCount: number;
+  starRatingScoreTotal: number;
+  starRatingCount: number;
+  starRatingAvg: number;
+  reviewCount: number;
+  viewCount: number;
+  createdAt: string;
+}>;
+
 export default class AdminAnimeApi extends AnimeApi {
   create(dto: CreateAnimeDto): Promise<void> {
     return post(ADMIN_BASE_URL + "/animes", dto);
+  }
+
+  getPageList(query: GetAnimePagetQuery): Promise<PageAnimeResponse> {
+    const queryParams: Record<string, string> = {};
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (value !== undefined) {
+        queryParams[key] = String(value);
+      }
+    });
+
+    const queryString = new URLSearchParams(queryParams).toString();
+    return get(ADMIN_BASE_URL + `/animes?${queryString}`);
+  }
+
+  delete(id: number) {
+    return del(ADMIN_BASE_URL + `/animes/${id}`);
   }
 }

--- a/src/admins/features/animes/components/AdminAnimeList.tsx
+++ b/src/admins/features/animes/components/AdminAnimeList.tsx
@@ -1,65 +1,269 @@
-import { Button, Card, Flex, Group } from "@mantine/core";
-import { useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  Center,
+  Flex,
+  Group,
+  Pagination,
+  Skeleton,
+  Stack,
+  Table,
+  Title,
+  Text,
+  Menu,
+  ActionIcon,
+  Select,
+} from "@mantine/core";
+import { modals } from "@mantine/modals";
+import { DotsThreeVertical, PencilSimple, Trash } from "@phosphor-icons/react";
 import { Link } from "react-router-dom";
 
 import ADMIN_ROUTE from "@/admins/constants/path";
 
-export default function AdminAnimeList() {
-  const [selectedReleaseFilter, setSelectedReleaseFilter] = useState<
-    boolean | null
-  >(null);
+import useAnimes from "../hooks/useAnimes";
+import useDeleteAnime from "../hooks/useDeleteAnime";
 
-  // TODO: 애니 목록 API
+export default function AdminAnimeList() {
+  // const [selectedReleaseFilter, setSelectedReleaseFilter] = useState<
+  //   boolean | null
+  // >(null);
+
+  const {
+    data: animesResponse,
+    isLoading,
+    setCurrentPage,
+    setDisplaySize,
+  } = useAnimes();
+  const deleteAnime = useDeleteAnime();
+
+  const handleDisplaySize = (value: string | null) => {
+    if (!value) return;
+    // value에서 숫자 부분만 추출
+    const numberPattern = /\d+/g;
+    const numberStr = value.match(numberPattern)?.at(-1);
+    setDisplaySize(Number(numberStr));
+  };
+
+  if (isLoading) {
+    return (
+      <Card withBorder padding="xl">
+        <Stack gap="sm">
+          <Skeleton w="100%" height={45}></Skeleton>
+          <Skeleton w="100%" height={45}></Skeleton>
+          <Skeleton w="100%" height={45}></Skeleton>
+          <Skeleton w="100%" height={45}></Skeleton>
+          <Skeleton w="100%" height={45}></Skeleton>
+          <Skeleton w="100%" height={45}></Skeleton>
+          <Skeleton w="100%" height={45}></Skeleton>
+          <Skeleton w="100%" height={45}></Skeleton>
+          <Skeleton w="100%" height={45}></Skeleton>
+          <Skeleton w="100%" height={45}></Skeleton>
+          <Skeleton w="100%" height={45}></Skeleton>
+        </Stack>
+      </Card>
+    );
+  }
+
+  const rows = animesResponse?.items.map((anime) => (
+    <Table.Tr key={anime.id}>
+      <Table.Td>
+        <Group>
+          <Title order={3} size="14px">
+            {anime.title}
+          </Title>
+          <Text size="xs">
+            {anime.year}년 {anime.quarter.at(-1)}분기
+          </Text>
+        </Group>
+      </Table.Td>
+      <Table.Td>
+        <ReleasedBadge isReleased={anime.isReleased} />
+      </Table.Td>
+      <Table.Td>
+        <StatusBadge status={anime.status} />
+      </Table.Td>
+      <Table.Td>
+        <time dateTime={convertDateTime(anime.createdAt)}>
+          {convertDateTime(anime.createdAt)}
+        </time>
+      </Table.Td>
+      <Table.Td>
+        <OptionMenu
+          animeId={anime.id}
+          onRemove={(animeId) => deleteAnime.mutate(animeId)}
+        />
+      </Table.Td>
+    </Table.Tr>
+  ));
 
   return (
     <Card withBorder padding="xl">
       <Flex justify="space-between" mb="sm">
-        <ReleaseFilters
+        {/* <ReleaseFilters
           selectedValue={selectedReleaseFilter}
           onSelect={(value) => setSelectedReleaseFilter(value)}
+        /> */}
+        <Select
+          data={["5개씩", "10개씩", "20개씩", "100개씩"]}
+          defaultValue="10개씩"
+          onChange={handleDisplaySize}
         />
-
         <Link to={ADMIN_ROUTE.CREATE_ANIME}>
           <Button>등록</Button>
         </Link>
       </Flex>
+
+      {/* 애니 목록 */}
+      <Table.ScrollContainer minWidth={500}>
+        <Table highlightOnHover verticalSpacing="md">
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>이름</Table.Th>
+              <Table.Th>공개</Table.Th>
+              <Table.Th>상태</Table.Th>
+              <Table.Th>생성일시</Table.Th>
+              <Table.Th>{/* 옵션 */}</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>{rows}</Table.Tbody>
+        </Table>
+      </Table.ScrollContainer>
+
+      {/* 페이지네이션 */}
+      <Center py="md">
+        <Pagination
+          size="sm"
+          total={animesResponse?.totalPages ?? 1}
+          boundaries={1}
+          onChange={(page) => setCurrentPage(page)}
+        />
+      </Center>
     </Card>
   );
 }
 
-const releaseFilterItems = [
-  {
-    label: "전체",
-    value: null,
-  },
-  {
-    label: "공개",
-    value: true,
-  },
-  {
-    label: "비공개",
-    value: false,
-  },
-];
+// const releaseFilterItems = [
+//   {
+//     label: "전체",
+//     value: null,
+//   },
+//   {
+//     label: "공개",
+//     value: true,
+//   },
+//   {
+//     label: "비공개",
+//     value: false,
+//   },
+// ];
 
-interface ReleaseFiltersProps {
-  selectedValue: boolean | null;
-  onSelect: (value: boolean | null) => void;
+// interface ReleaseFiltersProps {
+//   selectedValue: boolean | null;
+//   onSelect: (value: boolean | null) => void;
+// }
+
+// function ReleaseFilters({ selectedValue, onSelect }: ReleaseFiltersProps) {
+//   return (
+//     <Group gap="xs">
+//       {releaseFilterItems.map((item) => (
+//         <Button
+//           key={String(item.value)}
+//           variant={selectedValue === item.value ? "light" : "default"}
+//           c={selectedValue === item.value ? "gray.c" : undefined}
+//           onClick={() => onSelect(item.value)}
+//         >
+//           {item.label}
+//         </Button>
+//       ))}
+//     </Group>
+//   );
+// }
+
+/** 공개여부 뱃지 */
+function ReleasedBadge({ isReleased }: { isReleased: boolean }) {
+  return (
+    <Badge variant="light" color={isReleased ? "green" : "gray"}>
+      {isReleased ? "공개" : "비공개"}
+    </Badge>
+  );
 }
 
-function ReleaseFilters({ selectedValue, onSelect }: ReleaseFiltersProps) {
+/** 방영상태 뱃지 */
+function StatusBadge({ status }: { status: AnimeStatus }) {
+  let color;
+  let text;
+
+  switch (status) {
+    case "ONGOING":
+      color = "green";
+      text = "방영중";
+      break;
+    case "FINISHED":
+      color = "blue";
+      text = "완결";
+      break;
+    case "UPCOMING":
+      color = "orange";
+      text = "방영예정";
+      break;
+    case "UNKNOWN":
+      color = "gray";
+      text = "알 수 없음";
+      break;
+    default:
+      break;
+  }
+
   return (
-    <Group gap="xs">
-      {releaseFilterItems.map((item) => (
-        <Button
-          key={String(item.value)}
-          variant={selectedValue === item.value ? "light" : "default"}
-          c={selectedValue === item.value ? "gray.c" : undefined}
-          onClick={() => onSelect(item.value)}
-        >
-          {item.label}
-        </Button>
-      ))}
-    </Group>
+    <Badge variant="light" color={color}>
+      {text}
+    </Badge>
   );
+}
+
+interface OptionMenuProps {
+  /** 옵션 대상 애니메이션 아이디 */
+  animeId: number;
+  onRemove: (animeId: number) => void;
+}
+
+function OptionMenu({ animeId, onRemove }: OptionMenuProps) {
+  return (
+    <Menu>
+      <Menu.Target>
+        <ActionIcon variant="subtle" color="default" aria-label="옵션">
+          <DotsThreeVertical />
+        </ActionIcon>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <Menu.Item leftSection={<PencilSimple size={16} />}>
+          수정(미구현)
+        </Menu.Item>
+        <Menu.Item
+          leftSection={<Trash size={16} />}
+          color="red"
+          onClick={() =>
+            modals.openConfirmModal({
+              title: <Title size="h5">삭제</Title>,
+              centered: true,
+              children: <Center>정말로 애니메이션을 삭제하시나요?</Center>,
+              labels: { confirm: "삭제", cancel: "취소" },
+              confirmProps: { color: "red" },
+              onConfirm: () => onRemove(animeId),
+            })
+          }
+        >
+          삭제
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}
+
+/** "2023-11-01T12:10:06.834904" -> "2023-11-01" */
+function convertDateTime(dateTime: string) {
+  const date = new Date(dateTime);
+  return date.toISOString().split("T")[0];
 }

--- a/src/admins/features/animes/components/AdminAnimeSearch.tsx
+++ b/src/admins/features/animes/components/AdminAnimeSearch.tsx
@@ -33,7 +33,7 @@ export default function AdminAnimeSearch() {
             radius="md"
             leftSection={<MagnifyingGlass size={16} />}
           >
-            검색
+            검색(미구현)
           </Button>
           <Button type="submit" variant="default" radius="md">
             초기화

--- a/src/admins/features/animes/components/ManageSubCategory/ManageSubCategoryModal.tsx
+++ b/src/admins/features/animes/components/ManageSubCategory/ManageSubCategoryModal.tsx
@@ -109,12 +109,7 @@ export default function ManageSubCategoryModal({
                   <Table.Th>이름</Table.Th>
                   <Table.Th>관리</Table.Th>
                   <Table.Th>
-                    <Button
-                      variant="default"
-                      size="xs"
-                      fw={400}
-                      onClick={handleCreate}
-                    >
+                    <Button variant="default" size="xs" onClick={handleCreate}>
                       등록
                     </Button>
                   </Table.Th>
@@ -129,7 +124,6 @@ export default function ManageSubCategoryModal({
                         <Button
                           variant="default"
                           size="xs"
-                          fw={400}
                           onClick={() => handleEdit(d)}
                         >
                           수정
@@ -137,7 +131,6 @@ export default function ManageSubCategoryModal({
                         <Button
                           variant="default"
                           size="xs"
-                          fw={400}
                           onClick={() => handleDelete(d)}
                         >
                           삭제

--- a/src/admins/features/animes/components/ManageSubCategory/ManageVoiceActorsModal.tsx
+++ b/src/admins/features/animes/components/ManageSubCategory/ManageVoiceActorsModal.tsx
@@ -212,7 +212,6 @@ export default function EditVoiceActorsModal({
             <Button
               variant="default"
               size="xs"
-              fw={400}
               onClick={() => handleEdit(actor)}
             >
               수정
@@ -220,7 +219,6 @@ export default function EditVoiceActorsModal({
             <Button
               variant="default"
               size="xs"
-              fw={400}
               onClick={() => handleDelete(actor)}
             >
               삭제
@@ -251,12 +249,7 @@ export default function EditVoiceActorsModal({
               />
             </div>
             <Flex justify="flex-end" gap="sm">
-              <Button
-                variant="default"
-                size="xs"
-                fw={400}
-                onClick={handleCreate}
-              >
+              <Button variant="default" size="xs" onClick={handleCreate}>
                 새 성우
               </Button>
               <Button size="xs" onClick={handleSubmit}>

--- a/src/admins/features/animes/hooks/useAnimes.ts
+++ b/src/admins/features/animes/hooks/useAnimes.ts
@@ -1,0 +1,57 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+import useAdminApi from "@/admins/hooks/useAdminApi";
+
+import { GetAnimePagetQuery } from "../api/AdminAnimeApi";
+
+export default function useAnimes() {
+  const [searchQuery, setSearchQuery] = useState<GetAnimePagetQuery>({
+    query: "",
+    page: 1,
+    size: 10,
+    direction: "DESC",
+    queryType: "TITLE",
+    statuses: [],
+  });
+  const { animeApi } = useAdminApi();
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["animes", searchQuery],
+    queryFn: () => animeApi.getPageList(searchQuery),
+    keepPreviousData: true,
+  });
+
+  const setCurrentPage = (page: number) => {
+    setSearchQuery((prev) => ({
+      ...prev,
+      page,
+    }));
+  };
+
+  /** 한 페이지당 보여질 개수 */
+  const setDisplaySize = (size: number) => {
+    setSearchQuery((prev) => ({
+      ...prev,
+      size,
+    }));
+  };
+
+  /** 다음 페이지 미리 요청 */
+  useEffect(() => {
+    if (!data) return;
+
+    const { page: currentPage } = searchQuery;
+
+    if (currentPage < data.totalPages) {
+      const nextPage = currentPage + 1;
+      queryClient.prefetchQuery({
+        queryKey: ["animes", { ...searchQuery, page: nextPage }],
+        queryFn: () => animeApi.getPageList({ ...searchQuery, page: nextPage }),
+      });
+    }
+  }, [animeApi, data, queryClient, searchQuery]);
+
+  return { data, isLoading, ...searchQuery, setCurrentPage, setDisplaySize };
+}

--- a/src/admins/features/animes/hooks/useAnimes.ts
+++ b/src/admins/features/animes/hooks/useAnimes.ts
@@ -34,6 +34,7 @@ export default function useAnimes() {
   const setDisplaySize = (size: number) => {
     setSearchQuery((prev) => ({
       ...prev,
+      page: 1,
       size,
     }));
   };

--- a/src/admins/features/animes/hooks/useDeleteAnime.ts
+++ b/src/admins/features/animes/hooks/useDeleteAnime.ts
@@ -1,0 +1,31 @@
+import { notifications } from "@mantine/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import useAdminApi from "@/admins/hooks/useAdminApi";
+
+export default function useDeleteAnime() {
+  const { animeApi } = useAdminApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => animeApi.delete(id),
+    onSuccess: () => {
+      notifications.show({ message: "애니가 삭제되었어요", color: "green" });
+      queryClient.invalidateQueries({
+        queryKey: ["animes"],
+      });
+    },
+    onError: (e) => {
+      if (e instanceof AxiosError && e.response?.status === 404) {
+        notifications.show({
+          message: "존재하지 않는 애니에요",
+          color: "red",
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["animes"],
+        });
+      }
+    },
+  });
+}

--- a/src/admins/libs/mantine/theme.ts
+++ b/src/admins/libs/mantine/theme.ts
@@ -1,4 +1,4 @@
-import { CSSVariablesResolver, createTheme } from "@mantine/core";
+import { Button, CSSVariablesResolver, createTheme } from "@mantine/core";
 
 import { blueGray } from "./colors";
 
@@ -8,6 +8,13 @@ export const theme = createTheme({
     blueGray,
   },
   primaryColor: "blueGray",
+  components: {
+    Button: Button.extend({
+      defaultProps: {
+        fw: 400,
+      },
+    }),
+  },
 });
 
 export const resolver: CSSVariablesResolver = (theme) => ({

--- a/src/types/business.d.ts
+++ b/src/types/business.d.ts
@@ -16,3 +16,17 @@ declare interface CursorPage<T> {
   hasNext: boolean;
   cursor: string;
 }
+
+/**
+ * 일반 페이지의 응답 스키마입니다
+ * 제네릭을 사용하여 items T를 지정합니다
+ * @example
+ * Page<SomeType>
+ */
+declare interface Page<T> {
+  items: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}


### PR DESCRIPTION
## 📝 개요

- 관리자 애니 목록 페이지네이션

https://github.com/oduck-team/oduck-client/assets/105474635/0221cc7a-0614-484e-a9d2-20a7e7d385c4

- 관리자 애니 삭제

https://github.com/oduck-team/oduck-client/assets/105474635/fa0094c3-f27d-44f9-a68c-f9fdd7dc3ad6



## 🚀 변경사항

[feat: 페이지 응답 타입 추가](https://github.com/oduck-team/oduck-client/commit/631492f9dda26d8748bf289d9c6c0fbf6cd96d7b)

## 🔗 관련 이슈

#289

## ➕ 기타

- 원래 애니 썸네일도 표시 하려했으나, R2 스토리지 읽기 횟수가 너무 증가해서 제거했습니답

