### PR TITLE
feat: 애니 상세페이지 사용자 평점 반영 및 애니 평균 별점 조회 구현

### DIFF
--- a/src/features/animes/api/AnimeApi.ts
+++ b/src/features/animes/api/AnimeApi.ts
@@ -73,4 +73,8 @@ export default class AnimeApi {
     const queryString = new URLSearchParams(queryParams).toString();
     return get(`/animes?${queryString}`);
   }
+
+  getAverageRating(id: number) {
+    return get<{ starRatingAvg: number }>(`/animes/${id}/ratings/average`);
+  }
 }

--- a/src/features/animes/hooks/useAnime.ts
+++ b/src/features/animes/hooks/useAnime.ts
@@ -7,8 +7,19 @@ export default function useAnime(animeId: number) {
   const { animeApi } = useApi();
   const { user } = useAuth();
 
-  return useQuery({
+  const { data } = useQuery({
+    queryKey: ["averageRating", animeId, user?.memberId],
+    queryFn: () => animeApi.getAverageRating(animeId),
+  });
+
+  const { data: anime, isLoading } = useQuery({
     queryKey: ["anime", animeId, user?.memberId],
     queryFn: () => animeApi.getById(animeId),
   });
+
+  const starRatingAvg = data
+    ? Math.floor((data.starRatingAvg / 2) * 10) / 10
+    : 0;
+
+  return { starRatingAvg, anime, isLoading };
 }

--- a/src/features/animes/routes/Detail/Hero/index.tsx
+++ b/src/features/animes/routes/Detail/Hero/index.tsx
@@ -55,7 +55,7 @@ export default function Hero({
   genres,
   episodeCount,
   status,
-  // starScoreAvg,
+  starScoreAvg,
   reviewCount,
   bookmarkCount,
   year,
@@ -112,7 +112,7 @@ export default function Hero({
         <Stat
           variant="primary"
           items={[
-            { title: "별점", data: `★ 4.8` },
+            { title: "별점", data: `★ ${starScoreAvg}` },
             { title: "한줄리뷰", data: `${reviewCount}` },
             { title: "덕후", data: `${bookmarkCount}` },
             { title: "방영년도", data: `${year}` },

--- a/src/features/animes/routes/Detail/Ratings/index.tsx
+++ b/src/features/animes/routes/Detail/Ratings/index.tsx
@@ -14,7 +14,7 @@ import {
   Grid,
 } from "./style";
 
-export default function Ratings() {
+export default function Ratings({ starScoreAvg }: { starScoreAvg: number }) {
   return (
     <Section>
       <h1>평점</h1>
@@ -23,7 +23,7 @@ export default function Ratings() {
           <span>
             <Star size={36} weight="fill" />
           </span>
-          <span>4.2</span>
+          <span>{starScoreAvg}</span>
         </AverageRatingsOverview>
         <Rating
           readonly

--- a/src/features/animes/routes/Detail/Ratings/index.tsx
+++ b/src/features/animes/routes/Detail/Ratings/index.tsx
@@ -24,6 +24,7 @@ export default function Ratings({ starScoreAvg }: { starScoreAvg: number }) {
           <span>{starScoreAvg}</span>
         </AverageRatingsOverview>
         <Rating
+          value={starScoreAvg * 2}
           readonly
           style={{
             marginTop: "2px",

--- a/src/features/animes/routes/Detail/Ratings/index.tsx
+++ b/src/features/animes/routes/Detail/Ratings/index.tsx
@@ -20,9 +20,7 @@ export default function Ratings({ starScoreAvg }: { starScoreAvg: number }) {
       <h1>평점</h1>
       <AverageRatings>
         <AverageRatingsOverview>
-          <span>
-            <Star size={36} weight="fill" />
-          </span>
+          <Star size={36} weight="fill" />
           <span>{starScoreAvg}</span>
         </AverageRatingsOverview>
         <Rating

--- a/src/features/animes/routes/Detail/Ratings/style.ts
+++ b/src/features/animes/routes/Detail/Ratings/style.ts
@@ -10,16 +10,16 @@ export const AverageRatings = styled.div`
 export const AverageRatingsOverview = styled.div`
   display: flex;
   justify-content: center;
+  align-items: center;
   gap: 4px;
 
   & > span {
     font-size: 32px;
     font-weight: 500;
     letter-spacing: -1.6px;
-
-    & > svg {
-      color: ${({ theme }) => theme.colors.secondary["50"]};
-    }
+  }
+  & > svg {
+    color: ${({ theme }) => theme.colors.secondary["50"]};
   }
 `;
 

--- a/src/features/animes/routes/Detail/index.tsx
+++ b/src/features/animes/routes/Detail/index.tsx
@@ -16,7 +16,11 @@ import { AnimeDetailContainer } from "./style";
 export default function AnimeDetail() {
   const { id: animeId } = useParams();
 
-  const { data: anime, isLoading: isAnimeLoading } = useAnime(Number(animeId));
+  const {
+    starRatingAvg,
+    anime,
+    isLoading: isAnimeLoading,
+  } = useAnime(Number(animeId));
 
   const {
     reviews,
@@ -37,7 +41,7 @@ export default function AnimeDetail() {
         <Head title={`${anime.title} | 오덕`} image={anime.thumbnail} />
         <AnimeDetailContainer>
           {/* TODO: 평점 */}
-          <Hero {...anime} starScoreAvg={10} />
+          <Hero {...anime} starScoreAvg={starRatingAvg} />
           <SectionDivider />
 
           {/* 줄거리 및 정보 */}
@@ -48,7 +52,7 @@ export default function AnimeDetail() {
           <SectionDivider />
 
           {/* 평점 */}
-          <Ratings />
+          <Ratings starScoreAvg={starRatingAvg} />
           <SectionDivider />
 
           {/* 리뷰 목록 */}

--- a/src/features/reviews/components/ReviewRating/index.tsx
+++ b/src/features/reviews/components/ReviewRating/index.tsx
@@ -25,7 +25,6 @@ export default function ReviewRating({ animeId }: ReviewRatingProps) {
   const [isReviewModalVisible, setIsReviewModalVisible] = useState(false);
 
   const { data: evaluation, evaluationMutation } = useEvaluation(animeId);
-  console.log("평가 여부: ", evaluation?.createdAt);
 
   const handleRate = useDebounce((value: number) => {
     if (!user) {
@@ -39,8 +38,7 @@ export default function ReviewRating({ animeId }: ReviewRatingProps) {
   return (
     <>
       <Rating
-        value={evaluation ? 9 : 0}
-        // value={evaluated ? evaluation.score : 0}
+        value={evaluation ? evaluation.score : 0}
         size="lg"
         onRate={handleRate}
       />

--- a/src/features/reviews/hook/useEvaluation.ts
+++ b/src/features/reviews/hook/useEvaluation.ts
@@ -31,7 +31,8 @@ export default function useEvaluation(animeId: number) {
     onSuccess: () => {
       // 사용자의 평가 여부 및 score 조회 query 무효화
       queryClient.invalidateQueries(["evaluation", animeId, user?.memberId]);
-      // TODO: 애니 평균 평점 조회 query 무효화
+      // 애니 평균 평점 조회 query 무효화
+      queryClient.invalidateQueries(["averageRating", animeId, user?.memberId]);
     },
     onError: (error) => {
       if (error instanceof AxiosError && error.response?.status) {


### PR DESCRIPTION
## 📝 개요

https://github.com/oduck-team/oduck-client/assets/80813703/587514a7-7994-4850-ae61-f6ee7e3b9f52

- 사용자가 평가한 점수를 Rating 컴포넌트에 반영
- 애니 평균 별점 조회 및 값 바인딩
- 사용자가 평가 추가/수정 시 애니 평균 별점 조회 query 무효화

(현재 서버에서 추가/수정 시 평균 별점이 변경되지 않아 클라이언트 쪽에도 변화가 없습니다.)

## 🚀 변경사항



## 🔗 관련 이슈

#286 #237

## ➕ 기타



