### PR TITLE
fix: admin api path 오타

### DIFF
--- a/src/admins/features/animes/api/AdminVoiceActorApi.ts
+++ b/src/admins/features/animes/api/AdminVoiceActorApi.ts
@@ -19,10 +19,10 @@ export default class AdminVoiceActorApi {
   }
 
   update(id: number, dto: UpdateVoiceActorDto) {
-    return patch(ADMIN_BASE_URL + `//voice-actors/${id}`, dto);
+    return patch(ADMIN_BASE_URL + `/voice-actors/${id}`, dto);
   }
 
   delete(id: number) {
-    return del(ADMIN_BASE_URL + `//voice-actors/${id}`);
+    return del(ADMIN_BASE_URL + `/voice-actors/${id}`);
   }
 }


### PR DESCRIPTION
## 📝 개요
```ts
return patch(ADMIN_BASE_URL + `//voice-actors/${id}`, dto);
```
슬래시가 두 번 들어가있어서 요청시 400 응답이 발생

## 🚀 변경사항
슬래시가 두번 들어간 코드 수정

## 🔗 관련 이슈

#301

## ➕ 기타



