### PR TITLE
feat: 입덕 포인트 추가, 조회 구현

### DIFF
--- a/src/features/reviews/api/review.ts
+++ b/src/features/reviews/api/review.ts
@@ -22,6 +22,13 @@ export interface UserEvaluation {
   score: number;
 }
 
+export type AttractionType =
+  | "STORY"
+  | "CHARACTER"
+  | "DRAWING"
+  | "VOICE_ACTOR"
+  | "MUSIC";
+
 export default class ReviewApi {
   /** @description 리뷰 작성 요청 */
   async addReview(review: AddReviewDto): Promise<void> {
@@ -105,5 +112,30 @@ export default class ReviewApi {
   /** @description 애니 별점 평가 여부 및 score 조회 */
   async getEvaluation(animeId: number) {
     return get<UserEvaluation>(`/ratings/${animeId}`);
+  }
+
+  // 입덕 포인트
+
+  /** @description 입덕 포인트 남기기 */
+  async addAttractionPoint(
+    animeId: number,
+    attractionElements: AttractionType[],
+  ) {
+    return post(`/attraction-points`, {
+      animeId,
+      attractionElements,
+    });
+  }
+
+  /** @description 입덕 포인트 존재 여부 조회 */
+  async getUserAttractionPointStatus(animeId: number) {
+    return get<{ isAttractionPoint: boolean }>(`/attraction-points/${animeId}`);
+  }
+
+  /** @description 리뷰 수정 시 입덕 포인트 조회 */
+  async getUserAttractionPoint(animeId: number, name: string) {
+    return get<AttractionPoint>(`/short-reviews/attraction-points`, {
+      params: { animeId, name },
+    });
   }
 }

--- a/src/features/reviews/api/reviewDev.ts
+++ b/src/features/reviews/api/reviewDev.ts
@@ -10,7 +10,12 @@ import recentReviewMock1 from "./mock/recentReview1.json";
 import recentReviewMock2 from "./mock/recentReview2.json";
 import recentReviewMock3 from "./mock/recentReview3.json";
 import recentReviewOnlyOneMock from "./mock/recentReviewOnlyOne.json";
-import { AddReviewDto, ReviewInfo, UserEvaluation } from "./review";
+import {
+  AddReviewDto,
+  AttractionType,
+  ReviewInfo,
+  UserEvaluation,
+} from "./review";
 
 export default class ReviewDevApi {
   /** @description 리뷰 작성 요청*/
@@ -70,5 +75,28 @@ export default class ReviewDevApi {
   /** @description 애니 별점 평가 여부 조회 */
   async getEvaluation(animeId: number) {
     return get<UserEvaluation>(`/ratings/${animeId}`);
+  }
+
+  /** @description 입덕 포인트 남기기 */
+  async addAttractionPoint(
+    animeId: number,
+    attractionElements: AttractionType[],
+  ) {
+    return post(`/attraction-points`, {
+      animeId,
+      attractionElements,
+    });
+  }
+
+  /** @description 입덕 포인트 존재 여부 조회 */
+  async getUserAttractionPointStatus(animeId: number) {
+    return get<{ isAttractionPoint: boolean }>(`/attraction-points/${animeId}`);
+  }
+
+  /** @description 리뷰 수정 시 입덕 포인트 조회 */
+  async getUserAttractionPoint(animeId: number, name: string) {
+    return get<AttractionPoint>(`/short-reviews/attraction-points`, {
+      params: { animeId, name },
+    });
   }
 }

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
@@ -19,15 +19,6 @@ import {
   RatingContainer,
 } from "./ReviewMoreButton.style";
 
-// TODO: 서버에서 가져오기
-const USER_MOCK_ATTRACTION = {
-  character: true,
-  art: true,
-  story: false,
-  voiceActing: false,
-  sound: true,
-};
-
 interface ReviewMoreButtonProps {
   isMine: boolean;
   reviewId: number;
@@ -71,7 +62,6 @@ export default function ReviewMoreButton({
         },
       },
     );
-    console.log(value);
   };
 
   const handleReviewDeleteClick = () => console.log("리뷰삭제");
@@ -150,7 +140,6 @@ export default function ReviewMoreButton({
               animeId,
               content,
               isSpoiler,
-              ...USER_MOCK_ATTRACTION,
             }}
           >
             <MyRating>내 별점</MyRating>

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
@@ -9,6 +9,7 @@ import useSnackBar from "@/components/SnackBar/useSnackBar";
 import useToast from "@/components/Toast/useToast";
 import DropDownModal from "@/features/users/components/DropDownModal";
 import useDropDownModal from "@/features/users/components/DropDownModal/useDropDownModal";
+import useDebounce from "@/hooks/useDebounce";
 
 import useEvaluation from "../../hook/useEvaluation";
 import ShortReviewModal from "../ReviewRating/ShortReviewModal";
@@ -27,6 +28,8 @@ interface ReviewMoreButtonProps {
   isSpoiler: boolean;
   score: number;
 }
+
+const DEBOUNCE_DELAY = 200;
 
 export default function ReviewMoreButton({
   isMine,
@@ -53,7 +56,7 @@ export default function ReviewMoreButton({
     handleReviewModalToggle();
   };
 
-  const handleRate = (value: number) => {
+  const handleRate = useDebounce((value: number) => {
     evaluationMutation.mutate(
       { score: value },
       {
@@ -62,7 +65,7 @@ export default function ReviewMoreButton({
         },
       },
     );
-  };
+  }, DEBOUNCE_DELAY);
 
   const handleReviewDeleteClick = () => console.log("리뷰삭제");
 

--- a/src/features/reviews/components/ReviewRating/ShortReviewModal.tsx
+++ b/src/features/reviews/components/ReviewRating/ShortReviewModal.tsx
@@ -54,7 +54,7 @@ export default function ShortReviewModal({
       isChecked: form.character,
     },
     {
-      name: "art",
+      name: "drawing",
       content: (
         <>
           현실 찢고 들어간듯한/이쁜
@@ -74,7 +74,7 @@ export default function ShortReviewModal({
       isChecked: form.story,
     },
     {
-      name: "voiceActing",
+      name: "voiceActor",
       content: (
         <>
           <strong>성우</strong>들의 미친 연기력
@@ -83,7 +83,7 @@ export default function ShortReviewModal({
       isChecked: form.voiceActor,
     },
     {
-      name: "sound",
+      name: "music",
       content: (
         <>
           가슴이 옹졸해지는 <strong style={{ marginLeft: 4 }}>음악</strong>

--- a/src/features/reviews/components/ReviewRating/ShortReviewModal.tsx
+++ b/src/features/reviews/components/ReviewRating/ShortReviewModal.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren } from "react";
 
+import DeferredComponent from "@/components/DeferredComponent";
 import Modal from "@/components/Modal";
 import Textarea from "@/components/TextArea";
 
@@ -94,64 +95,71 @@ export default function ShortReviewModal({
   ];
 
   return (
-    <Modal onClose={onClose} showBackdrop={showBackdrop}>
-      <Modal.Content>
-        <Title>한 줄 리뷰 모달</Title>
-        {children}
-        <ReviewContentSection>
-          <label htmlFor="content">작품에 대한 의견을 남겨주세요</label>
-          <Textarea
-            name="content"
-            placeholder="최대 100자 까지 입력 가능해요"
-            onChange={handleTextInputChange}
-            value={form.content}
-            warn={error}
-            message="최소 10자 이상 입력해 주세요."
-          />
-          <SpoilerCheckBox
-            name="isSpoiler"
-            checked={form.isSpoiler}
-            onChange={handleCheckboxChange}
-          />
-        </ReviewContentSection>
-        <AttractionPointSection>
-          <label htmlFor="attraction-point">
-            이 애니의 입덕포인트는 무엇인가요?
-          </label>
-          <p>
-            입덕 포인트 선택 시 <span>포인트</span>가 쌓여요!
-          </p>
-          <AttractionPointList>
-            {attractionPoints.map((point) => (
-              <li key={point.name}>
-                <AttractionPoint
-                  name={point.name}
-                  isChecked={point.isChecked}
-                  onChange={handleCheckboxChange}
-                >
-                  {point.content}
-                </AttractionPoint>
-              </li>
-            ))}
-          </AttractionPointList>
-        </AttractionPointSection>
-      </Modal.Content>
+    <DeferredComponent>
+      <Modal onClose={onClose} showBackdrop={showBackdrop}>
+        <Modal.Content>
+          <Title>한 줄 리뷰 모달</Title>
+          {children}
+          <ReviewContentSection>
+            <label htmlFor="content">작품에 대한 의견을 남겨주세요</label>
+            <Textarea
+              name="content"
+              placeholder="최대 100자 까지 입력 가능해요"
+              onChange={handleTextInputChange}
+              value={form.content}
+              warn={error}
+              message="최소 10자 이상 입력해 주세요."
+            />
+            <SpoilerCheckBox
+              name="isSpoiler"
+              checked={form.isSpoiler}
+              onChange={handleCheckboxChange}
+            />
+          </ReviewContentSection>
+          <AttractionPointSection>
+            <label htmlFor="attraction-point">
+              이 애니의 입덕포인트는 무엇인가요?
+            </label>
+            <p>
+              입덕 포인트 선택 시 <span>포인트</span>가 쌓여요!
+            </p>
+            <AttractionPointList>
+              {attractionPoints.map((point) => (
+                <li key={point.name}>
+                  <AttractionPoint
+                    name={point.name}
+                    isChecked={point.isChecked}
+                    onChange={handleCheckboxChange}
+                  >
+                    {point.content}
+                  </AttractionPoint>
+                </li>
+              ))}
+            </AttractionPointList>
+          </AttractionPointSection>
+        </Modal.Content>
 
-      <Modal.Actions direction="row">
-        <Button
-          name="닫기"
-          variant="solid"
-          color="neutral"
-          size="lg"
-          isBlock
-          onClick={onClose}
-        >
-          취소
-        </Button>
-        <Button name="평가 완료" isBlock size="lg" onClick={handleReviewSubmit}>
-          완료
-        </Button>
-      </Modal.Actions>
-    </Modal>
+        <Modal.Actions direction="row">
+          <Button
+            name="닫기"
+            variant="solid"
+            color="neutral"
+            size="lg"
+            isBlock
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            name="평가 완료"
+            isBlock
+            size="lg"
+            onClick={handleReviewSubmit}
+          >
+            완료
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    </DeferredComponent>
   );
 }

--- a/src/features/reviews/components/ReviewRating/ShortReviewModal.tsx
+++ b/src/features/reviews/components/ReviewRating/ShortReviewModal.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren } from "react";
 import Modal from "@/components/Modal";
 import Textarea from "@/components/TextArea";
 
+import { ReviewInfo } from "../../api/review";
 import useReviewForm from "../../hook/useReviewForm";
 import AttractionPoint from "../AttractionPoint";
 
@@ -15,23 +16,16 @@ import {
 } from "./ShortReviewModal.style";
 import SpoilerCheckBox from "./SpoilerCheckBox";
 
-export interface MOCK_USER_REVIEW_DATA {
-  reviewId: number;
-  animeId: number;
-  content: string;
-  isSpoiler: boolean;
-  character: boolean;
-  art: boolean;
-  story: boolean;
-  voiceActing: boolean;
-  sound: boolean;
-}
+export type UserReview = Pick<
+  ReviewInfo,
+  "reviewId" | "animeId" | "content" | "isSpoiler"
+>;
 
 interface ShortReviewModalProps {
   onClose: () => void;
   onReview: () => void;
   showBackdrop?: boolean;
-  userReviewData?: MOCK_USER_REVIEW_DATA;
+  userReviewData?: UserReview;
 }
 
 export default function ShortReviewModal({
@@ -67,7 +61,7 @@ export default function ShortReviewModal({
           <strong style={{ marginLeft: 4 }}>그림체</strong>
         </>
       ),
-      isChecked: form.art,
+      isChecked: form.drawing,
     },
     {
       name: "story",
@@ -86,7 +80,7 @@ export default function ShortReviewModal({
           <strong>성우</strong>들의 미친 연기력
         </>
       ),
-      isChecked: form.voiceActing,
+      isChecked: form.voiceActor,
     },
     {
       name: "sound",
@@ -95,7 +89,7 @@ export default function ShortReviewModal({
           가슴이 옹졸해지는 <strong style={{ marginLeft: 4 }}>음악</strong>
         </>
       ),
-      isChecked: form.sound,
+      isChecked: form.music,
     },
   ];
 

--- a/src/features/reviews/hook/useAttractionPoint.ts
+++ b/src/features/reviews/hook/useAttractionPoint.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import useAuth from "@/features/auth/hooks/useAuth";
+import { useApi } from "@/hooks/useApi";
+import { useCommonToastError } from "@/libs/error";
+
+import { AttractionType } from "../api/review";
+
+export default function useAttractionPoint(animeId: number) {
+  const { reviewApi } = useApi();
+  const { user } = useAuth();
+  const { toastAuthError, toastDefaultError } = useCommonToastError();
+  const queryClient = useQueryClient();
+
+  // 사용자가 남긴 입덕 포인트 조회
+  const { data: userAttraction } = useQuery({
+    queryKey: ["attraction", animeId, user?.name],
+    queryFn: () => reviewApi.getUserAttractionPoint(animeId, user?.name ?? ""),
+    enabled: Boolean(user?.name),
+  });
+
+  // 사용자의 입덕 포인트 존재 여부 조회
+  const { data: status } = useQuery({
+    queryKey: ["attraction", animeId, "status", user?.memberId],
+    queryFn: () => reviewApi.getUserAttractionPointStatus(animeId),
+  });
+
+  // 입덕 포인트 추가
+  const addAttraction = useMutation({
+    mutationFn: (attractions: AttractionType[]) =>
+      reviewApi.addAttractionPoint(animeId, attractions),
+    onSuccess: () => {
+      queryClient.invalidateQueries(["attraction", animeId]);
+      // TODO: 애니 입덕 포인트 통계 query 무효화
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError && error.response?.status) {
+        const status = error.response.status;
+        switch (status) {
+          case 401:
+            toastAuthError();
+            break;
+          default:
+            toastDefaultError();
+            break;
+        }
+      }
+    },
+  });
+
+  return { userAttraction, status, addAttraction };
+}

--- a/src/features/reviews/types/index.d.ts
+++ b/src/features/reviews/types/index.d.ts
@@ -14,3 +14,11 @@ declare interface Review {
     avgScore: number;
   };
 }
+
+declare interface AttractionPoint {
+  drawing: boolean;
+  story: boolean;
+  music: boolean;
+  character: boolean;
+  voiceActor: boolean;
+}


### PR DESCRIPTION
## 📝 개요

입덕 포인트 추가, 조회 구현

- 입덕 포인트 추가

https://github.com/oduck-team/oduck-client/assets/80813703/1dbf9a48-78ca-42ef-9553-1000a3cca63b

(현재 입덕 포인트에 DRAWING (그림체)를 포함할 경우 서버에서 500 응답이 옵니다.)

- 리뷰 수정 시 입덕 포인트 존재 여부, 내가 남긴 입덕 포인트 조회 

https://github.com/oduck-team/oduck-client/assets/80813703/8b2e2108-4437-44c1-b11a-b405d0d1e023


## 🚀 변경사항

- 리뷰 수정 모달에서 별점, 확인 버튼에 debounce 적용

## 🔗 관련 이슈

#303

## ➕ 기타

리뷰 수정 모달 띄울 때 내가 남긴 입덕 포인트 데이터가 살짝 늦게 적용이 되는데 그렇다고 입덕 포인트 데이터 요청을 모달 밖에서 수행하기엔 마이페이지 내 리뷰 목록 같은 곳에서는 리뷰 개수만큼 요청이 될 것 같기도 하고 좀 효율적이지 않다는 생각이 들어서 일단 이렇게 뒀는데 개선할 수 있는 방법이 있을까요?🤔 로딩중일 땐 로더 컴포넌트라도 넣어야 할지 고민입니다..

**+ 11/23**

https://github.com/oduck-team/oduck-client/assets/80813703/15f5b808-6ca9-4a95-8b9b-6932e69053c2

defer 적용하였습니다!

<br/>





