### PR TITLE
fix: 로그인 상태에서 privatRoute 새로고침 시, 로그인 페이지로 이동하는 오류 수정

### DIFF
--- a/src/features/auth/contexts/AuthContext.tsx
+++ b/src/features/auth/contexts/AuthContext.tsx
@@ -42,14 +42,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
 
   const fetchUser = useCallback(async () => {
     try {
-      console.log("fetchUser 시도");
       const user = await authApi.getStatus();
-      console.log(`fetchUser user: ${JSON.stringify(user)}`);
       setUser(user);
       setAutoLogin(true);
-      console.log("fetchUser 끝");
     } catch (e) {
-      console.log("fetchUser 오류 발생");
       setUser(undefined);
       removeAutoLogin();
     }
@@ -64,10 +60,8 @@ export function AuthProvider({ children }: PropsWithChildren) {
 
   /** 자동 로그인이 설정된 경우에 유저 정보 가져옴 */
   useEffect(() => {
-    console.log("AuthProvider useEffect");
     if (isAutoLogin) {
       fetchUser();
-      console.log("AuthProvider fetchUser 끝");
     }
   }, [isAutoLogin]);
 

--- a/src/features/auth/routes/Login/index.tsx
+++ b/src/features/auth/routes/Login/index.tsx
@@ -26,7 +26,6 @@ export default function Login() {
    * sessionStorage에 저장된 prevPath를 redirect path로 지정
    */
   useEffect(() => {
-    console.log("Login 페이지 redirect url 지정");
     setRedirect(sessionStorage.getItem("prevPath") ?? "/");
   }, [location, setRedirect]);
 

--- a/src/routes/privateRoutes.tsx
+++ b/src/routes/privateRoutes.tsx
@@ -19,27 +19,13 @@ function PrivateRoute({ children }: PropsWithChildren) {
    * 유저 정보가 없다면 로그인 페이지로 이동합니다.
    */
   useEffect(() => {
-    console.log("PrivateRoute useEffect");
-    console.log(user);
-
     if (!user) {
-      if (isAutoLogin) {
-        console.log("(새로고침) 유저X 자동로그인O");
-        fetchUser();
-        // const handleFetchUser = async () => {
-        //   console.log("PrivateRoute handleFetchUser");
-        //   await fetchUser();
-        // };
-
-        // handleFetchUser();
-      } else {
-        console.log("PrivateRoute user가 없어서 로그인 페이지로 이동");
-        navigate("/login", { replace: true });
-      }
+      // 로그인 상태에서 새로고침 시, 로그인 페이지로 이동되는 오류 대응
+      // AutoLogin이 설정되어 있으면 유저정보를 새로 요청
+      if (isAutoLogin) fetchUser();
+      else navigate("/login", { replace: true });
     }
   }, [navigate, user, isAutoLogin]);
-
-  console.log("children 렌더링");
 
   return children;
 }


### PR DESCRIPTION
## 📝 개요
- 로그인 상태에서 privatRoute 새로고침 시, 로그인 페이지로 이동하는 오류 수정

## 🚀 변경사항
- privateRoute.tsx
```tsx
  useEffect(() => {
    if (!user) {
      // 로그인 상태에서 새로고침 시, 로그인 페이지로 이동되는 오류 대응
      // AutoLogin이 설정되어 있으면 유저정보를 새로 요청
      if (isAutoLogin) fetchUser();
      else navigate("/login", { replace: true });
    }
  }, [navigate, user, isAutoLogin]);
```

프로덕션 환경에서 user state가 업데이트 되기전에 privateRoute의 useEffect가 실행되어, 
새로고침 시 항상 로그인 페이지로 이동했는데 이 문제를 수정했습니다.

-------------
- #### 기존 개발환경
```tsx
  const fetchUser = useCallback(async () => {
    try {
      console.log("AuthProfivder fetchUser try");
      const user = await authApi.getStatus();
      console.log(user);
      setUser(user);
      setAutoLogin(true);
      console.log("AuthProfivder fetchUser end");
    } catch (e) {
      setUser(undefined);
      removeAutoLogin();
    }
  }, [authApi, removeAutoLogin, setAutoLogin]);
```

![image](https://github.com/oduck-team/oduck-client/assets/115006670/f2844b97-9ad6-4971-9978-5430dc3e520a)

user state가 업데이트 된 뒤 privateRoute의 useEffect 실행되어 로그인 페이지로 이동 발생하지 않음.

-----------------
- #### 기존 프로덕션 환경

![로그인1](https://github.com/oduck-team/oduck-client/assets/115006670/df79661c-e66f-4a75-ba38-b5f9fbe61d79)

유저 정보를 fetch 했지만 user state가 업데이트 되지 않은채로 privateRoute의 useEffect가 실행되어 로그인 페이지로 이동되었습니다. 그 이후 user 정보가 출력됨

------------------
- #### 이 현상이 발생한 이유
`const user = await authApi.getStatus();`

유저 상태 요청을 기다리는 동안, 다른 비동기 함수나 작업(privateRoute의 useEffect)이 동작해서 이 문제가 발생한 거 같습니다.

개발 환경은 프로덕션 환경보다 서버간 딜레이가 작아서 user state가 바로 업데이트된 거 같습니다.

다른 이유가 있다고 생각된다면 공유 부탁드립니다!


## 🔗 관련 이슈
#314

## ➕ 기타


