### PR TITLE
fix: 프로필 수정 페이지 오류 및 개선사항 적용

### DIFF
--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -6,11 +6,14 @@ export interface TextareaProps extends ComponentProps<"textarea"> {
   warn?: boolean;
   message?: string;
   className?: string;
+  /** px단위 */
+  height?: string;
 }
 
 export interface TextareaBoxProps extends ComponentProps<"textarea"> {
   warn?: boolean;
   negativeMargin: number; // scale 후 여백 제거를 위한 negative margin
+  height?: string; // px단위
 }
 
 export default function Textarea({
@@ -18,6 +21,7 @@ export default function Textarea({
   message = "",
   style,
   className = "",
+  height,
   ...rest
 }: TextareaProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -37,6 +41,7 @@ export default function Textarea({
         negativeMargin={negativeMargin}
         ref={textareaRef}
         warn={warn}
+        height={height}
         {...rest}
       />
       {warn && message !== "" && <Message>{message}</Message>}

--- a/src/components/TextArea/style.ts
+++ b/src/components/TextArea/style.ts
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import { TextareaBoxProps } from ".";
 
 export const TextareaBox = styled.textarea<TextareaBoxProps>`
-  ${({ warn = false, theme, negativeMargin }) => css`
+  ${({ warn = false, theme, negativeMargin, height }) => css`
     ${theme.typo["body-2-r"]};
     --scale: 1.1429;
     width: calc(100% * var(--scale));
@@ -24,6 +24,12 @@ export const TextareaBox = styled.textarea<TextareaBoxProps>`
       ${warn ? theme.colors["warn"]["40"] : theme.colors["neutral"]["30"]};
     transition: border 0.2s;
     resize: none;
+
+    /* height를 직접 지정한 경우 */
+    ${height &&
+    css`
+      height: calc(${height}px - ${negativeMargin}px);
+    `}
 
     &::placeholder {
       color: ${theme.colors["neutral"]["50"]};

--- a/src/features/auth/routes/Callback/index.tsx
+++ b/src/features/auth/routes/Callback/index.tsx
@@ -28,7 +28,6 @@ export default function Callback() {
   useEffect(() => {
     if (redirectUrl) {
       const handleFetchUser = async () => {
-        console.log("Callback handleFetchUser");
         await fetchUser();
         handleRedirect();
       };

--- a/src/features/users/hooks/useEditForm.tsx
+++ b/src/features/users/hooks/useEditForm.tsx
@@ -46,6 +46,18 @@ export default function useEditForm(name: string, description: string) {
 
   const handleFormSumbit = useDebounce(async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!isFormChange) return;
+
+    if (!isNicknameRegexCheck(form.name)) {
+      setStatus({
+        isWarn: true,
+        message:
+          "한글, 영문, 숫자만 입력 가능합니다. 한글 또는 영문은 반드시 포함하여 2자~10자 닉네임을 설정해주세요.",
+      });
+
+      return;
+    }
+
     updateProfile.mutate(undefined, {
       onSuccess: async () => {
         await queryClient.invalidateQueries(["profile", user?.name]);
@@ -70,15 +82,6 @@ export default function useEditForm(name: string, description: string) {
         }
       },
     });
-
-    if (!isNicknameRegexCheck(form.name)) {
-      setStatus({
-        isWarn: true,
-        message:
-          "한글, 영문, 숫자만 입력 가능합니다. 한글 또는 영문은 반드시 포함하여 2자~10자 닉네임을 설정해주세요.",
-      });
-      return;
-    }
 
     setStatus({ isWarn: false, message: "" });
   }, 200);

--- a/src/features/users/hooks/useEditForm.tsx
+++ b/src/features/users/hooks/useEditForm.tsx
@@ -75,6 +75,9 @@ export default function useEditForm(name: string, description: string) {
             case 400: // 정규식 검사 오류
               toast.error({ message: "사용할 수 없는 닉네임입니다." });
               break;
+            case 409: // 닉네임 중복 오류
+              toast.error({ message: "이미 사용중인 닉네임입니다." });
+              break;
             default:
               toastDefaultError();
               break;

--- a/src/features/users/hooks/useEditForm.tsx
+++ b/src/features/users/hooks/useEditForm.tsx
@@ -34,10 +34,7 @@ export default function useEditForm(name: string, description: string) {
   ) => {
     const { name, value } = e.target;
 
-    if (name === "name" && value.length > 10) {
-      setForm((prev) => ({ ...prev, name: prev.name.substring(0, 5) }));
-      return;
-    }
+    if (name === "name" && value.length > 10) return;
     if (name === "description" && value.length > 100) return;
 
     setForm((prev) => ({ ...prev, [name]: value }));

--- a/src/features/users/hooks/useEditForm.tsx
+++ b/src/features/users/hooks/useEditForm.tsx
@@ -50,6 +50,7 @@ export default function useEditForm(name: string, description: string) {
       onSuccess: async () => {
         await queryClient.invalidateQueries(["profile", user?.name]);
         await fetchUser();
+        queryClient.removeQueries(["profile", "edit", user?.name]);
         navigate("/profile");
       },
       onError: (error) => {

--- a/src/features/users/routes/Edit/EditForm/index.tsx
+++ b/src/features/users/routes/Edit/EditForm/index.tsx
@@ -40,6 +40,7 @@ export default function EditForm({ name, description }: EditFromProps) {
             value={form.description}
             placeholder="자기소개를 적어보세요(최대 100자까지 가능합니다)"
             maxLength={100}
+            height={"100"}
             spellCheck={false}
             onChange={(e) => handleInputChange(e)}
           />

--- a/src/features/users/routes/Edit/EditForm/index.tsx
+++ b/src/features/users/routes/Edit/EditForm/index.tsx
@@ -29,6 +29,7 @@ export default function EditForm({ name, description }: EditFromProps) {
             maxLength={10}
             message={status.message}
             warn={status.isWarn}
+            spellCheck={false}
             onChange={(e) => handleInputChange(e)}
           />
         </div>
@@ -39,6 +40,7 @@ export default function EditForm({ name, description }: EditFromProps) {
             value={form.description}
             placeholder="자기소개를 적어보세요(최대 100자까지 가능합니다)"
             maxLength={100}
+            spellCheck={false}
             onChange={(e) => handleInputChange(e)}
           />
         </div>


### PR DESCRIPTION
## 📝 개요
프로필 수정 페이지 오류 및 개선사항 적용

## 🚀 변경사항
1.  프로필 수정 후, 수정 페이지 query key 제거
     - 프로필 수정 후 다시 수정 페이지 이동 시, 자기소개가 이전 데이터를 유지하고있던 오류 수정

2. submit 요청이 발생하지 않는 조건 변경
   - form 데이터 변경사항 없는 경우
   - 닉네임 검사 실패한 경우 (early return 되도록 순서 변경)

3. 닉네임 중복 오류 처리
   - toast ui 설정

4. 기타 개선
   - 닉네임이 10글자 넘어가면 초기화 되는 현상 수정
   - input, textarea spellcheck false 설정
   - 자기소개 textarea height 설정 

## 🔗 관련 이슈
#326

## ➕ 기타

