### PR TITLE
feat: 프로필 페이지 한줄리뷰 api 적용

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -97,7 +97,7 @@ export default function Layout() {
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [location]);
+  }, [location.pathname]);
 
   return (
     <LayoutContainer>

--- a/src/contexts/OduckApiContext.tsx
+++ b/src/contexts/OduckApiContext.tsx
@@ -8,12 +8,11 @@ import FileApi from "@/features/files/api/FileApi";
 import ReviewApi from "@/features/reviews/api/review";
 import ReviewDevApi from "@/features/reviews/api/reviewDev";
 import ProfileApi from "@/features/users/api/profile";
-import ProfileDevApi from "@/features/users/api/profileDev";
 import { StrictPropsWithChildren } from "@/types";
 
 interface API {
   authApi: AuthApi;
-  profile: ProfileDevApi | ProfileApi;
+  profile: ProfileApi;
   animeApi: AnimeApi;
   genreApi: GenreApi;
   bookmarkApi: BookmarkApi;
@@ -26,7 +25,6 @@ export const OduckApiContext = createContext<API | null>(null);
 /** @desc: 서버 Api와 개발용 Api 선택 */
 const authApi = new AuthApi();
 const profile = new ProfileApi();
-// const profile = new ProfileDevApi();
 const animeApi = new AnimeApi();
 const genreApi = new GenreApi();
 const bookmarkApi = new BookmarkApi();

--- a/src/features/bookmarks/components/BookmarkCardSkeleton.tsx
+++ b/src/features/bookmarks/components/BookmarkCardSkeleton.tsx
@@ -1,0 +1,51 @@
+import styled from "@emotion/styled";
+
+import Skeleton from "@/components/Skeleton";
+
+export default function BookmarkCardSkeleton() {
+  return (
+    <BookmarkCardSkeletonContainer>
+      <ImageContainer>
+        <Skeleton w={80} h={100} />
+      </ImageContainer>
+      <InfoContainer>
+        <TitleContainer>
+          <Skeleton w={160} h={21} />
+        </TitleContainer>
+        <RatingContainer>
+          <Skeleton w={120} h={18} />
+        </RatingContainer>
+        <Skeleton w={60} h={16} />
+      </InfoContainer>
+    </BookmarkCardSkeletonContainer>
+  );
+}
+
+const BookmarkCardSkeletonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  height: 132px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.neutral[10]};
+  margin: 0 -16px;
+  padding: 0 16px;
+`;
+
+const ImageContainer = styled.div`
+  flex-shrink: 0;
+`;
+
+const InfoContainer = styled.div`
+  padding: 16px 0;
+  margin-left: 8px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const TitleContainer = styled.div`
+  margin-bottom: 28px;
+`;
+
+const RatingContainer = styled.div`
+  margin-bottom: 10px;
+`;

--- a/src/features/reviews/components/ReviewCard/ActionBar.style.ts
+++ b/src/features/reviews/components/ReviewCard/ActionBar.style.ts
@@ -7,6 +7,7 @@ export const ActionBarContainer = styled.div`
   justify-content: space-between;
   align-items: center;
   padding-top: 10px;
+  cursor: auto;
 `;
 
 export const ButtonContainer = styled.div`

--- a/src/features/reviews/components/ReviewCard/ActionBar.tsx
+++ b/src/features/reviews/components/ReviewCard/ActionBar.tsx
@@ -31,9 +31,9 @@ export default function ActionBar({
   const date = isTimeAgo ? timeAgo(createdAt) : dateWithDots(createdAt);
 
   return (
-    <ActionBarContainer>
+    <ActionBarContainer onClick={(e) => e.stopPropagation()}>
       {date && <time>{date}</time>}
-      <ButtonContainer onClick={(e) => e.stopPropagation()}>
+      <ButtonContainer>
         <ReviewLikeButton
           isLike={isLike}
           count={compactNumber(likeCount, "ko-KR")}

--- a/src/features/reviews/components/ReviewCard/Animation.style.ts
+++ b/src/features/reviews/components/ReviewCard/Animation.style.ts
@@ -5,13 +5,21 @@ export const AnimeConatiner = styled.div`
   margin-bottom: 8px;
 `;
 
-export const Image = styled.img`
+export const ImageContainer = styled.div`
   flex-shrink: 0;
   width: 60px;
   height: 74px;
+  overflow: hidden;
   border-radius: 4px;
-  background-color: #d9d9d9;
   margin-right: 8px;
+`;
+
+export const Image = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background-color: #d9d9d9;
+  transition: transform ease 0.2s;
 `;
 
 export const TitleContainer = styled.div`

--- a/src/features/reviews/components/ReviewCard/Animation.tsx
+++ b/src/features/reviews/components/ReviewCard/Animation.tsx
@@ -3,6 +3,7 @@ import Rating from "@/components/Rating";
 import {
   AnimeConatiner,
   Image,
+  ImageContainer,
   Title,
   TitleContainer,
 } from "./Animation.style";
@@ -18,7 +19,10 @@ interface AnimeProps {
 export default function Anime({ anime }: AnimeProps) {
   return (
     <AnimeConatiner>
-      <Image src={anime.thumbnail} alt={anime.title} />
+      <ImageContainer>
+        <Image src={anime.thumbnail} alt={anime.title} />
+      </ImageContainer>
+
       <TitleContainer>
         <Title>{anime.title}</Title>
         <Rating color="primary" value={anime.avgScore} size="sm" readonly />

--- a/src/features/reviews/components/ReviewCard/ReviewCardSkeleton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewCardSkeleton.tsx
@@ -1,0 +1,53 @@
+import styled from "@emotion/styled";
+
+import Skeleton from "@/components/Skeleton";
+
+/** 애니 이미지가 포함된 리뷰카드의 스켈레톤 */
+export default function ReviewCardSkeleton() {
+  return (
+    <ReviewCardSkeletonContainer>
+      <AnimeContainer>
+        <ImageContainer>
+          <Skeleton w={60} h={74} />
+        </ImageContainer>
+        <div>
+          <TitleContainer>
+            <Skeleton w={150} h={21} />
+          </TitleContainer>
+          <Skeleton w={70} h={22} />
+        </div>
+      </AnimeContainer>
+      <CommentContainer>
+        <Skeleton w={200} h={21} />
+      </CommentContainer>
+      <Skeleton w={70} h={18} />
+    </ReviewCardSkeletonContainer>
+  );
+}
+
+const ReviewCardSkeletonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 167px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.neutral[10]};
+  margin: 0 -16px;
+  padding: 16px;
+`;
+
+const AnimeContainer = styled.div`
+  display: flex;
+  margin-bottom: 8px;
+`;
+
+const ImageContainer = styled.div`
+  margin-right: 8px;
+`;
+
+const TitleContainer = styled.div`
+  margin-bottom: 20px;
+`;
+
+const CommentContainer = styled.div`
+  margin-bottom: 8px;
+`;

--- a/src/features/reviews/components/ReviewCard/style.ts
+++ b/src/features/reviews/components/ReviewCard/style.ts
@@ -10,8 +10,8 @@ export const ReviewCardContainer = styled.article<
   transition: background-color ease 0.1s;
 
   @media (hover: hover) and (pointer: fine) {
-    &:hover {
-      background-color: #fdfdfd;
+    &:hover img {
+      transform: scale(1.2);
     }
   }
 

--- a/src/features/users/api/profile.ts
+++ b/src/features/users/api/profile.ts
@@ -4,13 +4,16 @@ import { ProfileEditFormData } from "../hooks/useEditForm";
 import { SelectedSort } from "../hooks/useSortBar";
 import { MENU } from "../hooks/useTabMenu";
 
-import reveiwMock1 from "./mock/review1.json";
-import reveiwMock2 from "./mock/review2.json";
-import reveiwMock3 from "./mock/review3.json";
-
 export interface TabListCountResponse {
   count: number;
 }
+
+export type ReviewListResponse = Omit<Review, "anime"> & {
+  animeId: number;
+  title: string;
+  thumbnail: string;
+  score: number | null;
+};
 
 export default class ProfileApi {
   async getProfile(name: string | undefined): Promise<Profile> {
@@ -33,26 +36,12 @@ export default class ProfileApi {
     memberId: number,
     pageParam: string | undefined,
     selected: SelectedSort,
-  ): Promise<CursorPage<Review>> {
+  ): Promise<CursorPage<ReviewListResponse>> {
     const params = this.setParams(pageParam, selected);
-    // FIXME: /members/${memberId} 변경, log 제거
-    console.log(memberId);
-    console.log(params);
 
-    // FIXME: review api 완성 시, mock switch 삭제
-    switch (pageParam) {
-      case "2023-10-03T21:05:31.859":
-        return reveiwMock2;
-      case "2023-09-21T21:05:31.859":
-        return reveiwMock1;
-      default:
-        return reveiwMock3;
-    }
-
-    // FIXME: review api 완성 시, 주석 제거
-    // return await get(`/members/${"26"}/reviews`, {
-    //   params: params,
-    // });
+    return await get(`/members/${memberId}/short-reviews`, {
+      params: params,
+    });
   }
 
   async getTabListCount(
@@ -75,9 +64,8 @@ export default class ProfileApi {
 
     const order = selected.isDESC ? "DESC" : "ASC";
 
-    // FIXME: 사이즈 변경
     const baseParams = {
-      size: 2,
+      size: 10,
       sort,
       order,
     };

--- a/src/features/users/api/profileDev.ts
+++ b/src/features/users/api/profileDev.ts
@@ -1,49 +1,56 @@
-import bookmarkMock1 from "./mock/bookmark1.json";
-import bookmarkMock2 from "./mock/bookmark2.json";
-import bookmarkMock3 from "./mock/bookmark3.json";
-import profileMock from "./mock/profile.json";
-import reveiwMock1 from "./mock/review1.json";
-import reveiwMock2 from "./mock/review2.json";
-import reveiwMock3 from "./mock/review3.json";
-import { TabListCountResponse } from "./profile";
+// import bookmarkMock1 from "./mock/bookmark1.json";
+// import bookmarkMock2 from "./mock/bookmark2.json";
+// import bookmarkMock3 from "./mock/bookmark3.json";
+// import profileMock from "./mock/profile.json";
+// import reveiwMock1 from "./mock/review1.json";
+// import reveiwMock2 from "./mock/review2.json";
+// import reveiwMock3 from "./mock/review3.json";
+// import { TabListCountResponse, ReviewListResponse } from "./profile";
 
-export default class ProfileDevApi {
-  async getProfile(): Promise<Profile> {
-    return profileMock;
-  }
+/**
+ * deprecated
+ * 프로필 개발용 api를 더이상 사용하지 않습니다.
+ */
+// export default class ProfileDevApi {
+//   async getProfile(): Promise<Profile> {
+//     return profileMock;
+//   }
 
-  async getBookmark(
-    _: number,
-    pageParam: string,
-  ): Promise<CursorPage<Bookmark>> {
-    // 입덕 최신 순 정렬
-    switch (pageParam) {
-      case "2023-10-03T21:05:31.859":
-        return bookmarkMock2;
-      case "2023-09-21T21:05:31.859":
-        return bookmarkMock1;
-      default:
-        return bookmarkMock3;
-    }
-  }
+//   async getBookmark(
+//     _: number,
+//     pageParam: string,
+//   ): Promise<CursorPage<Bookmark>> {
+//     // 입덕 최신 순 정렬
+//     switch (pageParam) {
+//       case "2023-10-03T21:05:31.859":
+//         return bookmarkMock2;
+//       case "2023-09-21T21:05:31.859":
+//         return bookmarkMock1;
+//       default:
+//         return bookmarkMock3;
+//     }
+//   }
 
-  async getReview(_: number, pageParam: string): Promise<CursorPage<Review>> {
-    // 등록 최신 순 정렬
-    switch (pageParam) {
-      case "2023-10-03T21:05:31.859":
-        return reveiwMock2;
-      case "2023-09-21T21:05:31.859":
-        return reveiwMock1;
-      default:
-        return reveiwMock3;
-    }
-  }
+//   async getReview(
+//     _: number,
+//     pageParam: string,
+//   ): Promise<CursorPage<ReviewListResponse>> {
+//     // 등록 최신 순 정렬
+//     switch (pageParam) {
+//       case "2023-10-03T21:05:31.859":
+//         return reveiwMock2;
+//       case "2023-09-21T21:05:31.859":
+//         return reveiwMock1;
+//       default:
+//         return reveiwMock3;
+//     }
+//   }
 
-  async getTabListCount(): Promise<TabListCountResponse> {
-    return { count: 30 };
-  }
+//   async getTabListCount(): Promise<TabListCountResponse> {
+//     return { count: 30 };
+//   }
 
-  async updateProfile() {
-    console.log("닉네임, 자기소개 수정");
-  }
-}
+//   async updateProfile() {
+//     console.log("닉네임, 자기소개 수정");
+//   }
+// }

--- a/src/features/users/hooks/useTabMenu.ts
+++ b/src/features/users/hooks/useTabMenu.ts
@@ -36,6 +36,7 @@ export default function useTabMenu(memberId: number) {
   const {
     data: bookmarks,
     isLoading: isLoadingBookmark,
+    isFetchingNextPage: isFetchingBookmarkNext,
     fetchNextPage: fetchNextPageBookmark,
     hasNextPage: hasNextPageBookmark,
   } = useInfiniteQuery(
@@ -55,6 +56,7 @@ export default function useTabMenu(memberId: number) {
   const {
     data: reviews,
     isLoading: isLoadingReview,
+    isFetchingNextPage: isFetchingReviewNext,
     fetchNextPage: fetchNextPageReview,
     hasNextPage: hasNextPageReview,
   } = useInfiniteQuery(
@@ -91,8 +93,10 @@ export default function useTabMenu(memberId: number) {
     selected: selectedSort,
     bookmarks,
     isLoadingBookmark,
+    isFetchingBookmarkNext,
     reviews,
     isLoadingReview,
+    isFetchingReviewNext,
     handleTabMenuClick,
     SHEET_BUTTONS,
     handleSortClick,

--- a/src/features/users/hooks/useTabMenu.ts
+++ b/src/features/users/hooks/useTabMenu.ts
@@ -47,6 +47,7 @@ export default function useTabMenu(memberId: number) {
         pages: data.pages.flatMap((page) => page.items),
         pageParams: data.pageParams,
       }),
+      enabled: selectedMenu === "입덕애니",
     },
   );
 
@@ -65,6 +66,7 @@ export default function useTabMenu(memberId: number) {
         pages: data.pages.flatMap((page) => page.items),
         pageParams: data.pageParams,
       }),
+      enabled: selectedMenu === "한줄리뷰",
     },
   );
 

--- a/src/features/users/hooks/useTabMenu.ts
+++ b/src/features/users/hooks/useTabMenu.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useRef, useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useLocation, useSearchParams } from "react-router-dom";
 
 import useSortBar from "@/features/users/hooks/useSortBar";
 import { useApi } from "@/hooks/useApi";
@@ -16,14 +16,17 @@ export type MENU = typeof REVIEW_MENU | typeof BOOKMARK_MENU;
 
 export default function useTabMenu(memberId: number) {
   const targetRef = useRef(null);
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
+  const location = useLocation();
   const [selectedMenu, setSelectedMenu] = useState<MENU>(REVIEW_MENU);
   const handleTabMenuClick = (text: MENU) => {
     setSelectedMenu(text);
-    text === "한줄리뷰"
-      ? searchParams.set("tab", REVIEW)
-      : searchParams.set("tab", BOOKMARK);
-    setSearchParams(searchParams, { replace: true });
+    // queryString 설정
+    history.replaceState(
+      null,
+      "",
+      `?tab=${text === "한줄리뷰" ? REVIEW : BOOKMARK}`,
+    );
   };
   const {
     selected: selectedSort,
@@ -80,12 +83,15 @@ export default function useTabMenu(memberId: number) {
       selectedMenu === "입덕애니" ? hasNextPageBookmark : hasNextPageReview,
   });
 
-  /** queryString tab === 'bookmark'인 경우, 입덕애니 Menu 선택 */
+  /**
+   * queryString tab === 'bookmark'인 경우, 입덕애니 Menu 선택
+   * sidebar의 입덕애니 메뉴 클릭 또는 새로고침 시 실행
+   * */
   useEffect(() => {
     searchParams.get("tab") === BOOKMARK
       ? setSelectedMenu(BOOKMARK_MENU)
       : setSelectedMenu(REVIEW_MENU);
-  }, [searchParams]);
+  }, [location, searchParams]);
 
   return {
     targetRef,

--- a/src/features/users/hooks/useTabMenu.ts
+++ b/src/features/users/hooks/useTabMenu.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useRef, useEffect, useState } from "react";
-import { useLocation, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
 import useSortBar from "@/features/users/hooks/useSortBar";
 import { useApi } from "@/hooks/useApi";
@@ -16,17 +16,14 @@ export type MENU = typeof REVIEW_MENU | typeof BOOKMARK_MENU;
 
 export default function useTabMenu(memberId: number) {
   const targetRef = useRef(null);
-  const [searchParams] = useSearchParams();
-  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [selectedMenu, setSelectedMenu] = useState<MENU>(REVIEW_MENU);
   const handleTabMenuClick = (text: MENU) => {
     setSelectedMenu(text);
-    // queryString 설정
-    history.replaceState(
-      null,
-      "",
-      `?tab=${text === "한줄리뷰" ? REVIEW : BOOKMARK}`,
-    );
+    text === "한줄리뷰"
+      ? searchParams.set("tab", REVIEW)
+      : searchParams.set("tab", BOOKMARK);
+    setSearchParams(searchParams, { replace: true });
   };
   const {
     selected: selectedSort,
@@ -91,7 +88,7 @@ export default function useTabMenu(memberId: number) {
     searchParams.get("tab") === BOOKMARK
       ? setSelectedMenu(BOOKMARK_MENU)
       : setSelectedMenu(REVIEW_MENU);
-  }, [location, searchParams]);
+  }, [searchParams]);
 
   return {
     targetRef,

--- a/src/features/users/routes/Profile/ProfileLoading.tsx
+++ b/src/features/users/routes/Profile/ProfileLoading.tsx
@@ -28,10 +28,6 @@ export default function ProfileLoading() {
           <Skeleton w={120} h={21} />
           <Skeleton w={100} h={21} />
         </SortBarContainer>
-        <CardContainer>
-          <Skeleton w={"full"} h={135} />
-          <Skeleton w={"full"} h={135} />
-        </CardContainer>
       </ListContainer>
     </>
   );
@@ -68,10 +64,4 @@ const SortBarContainer = styled.div`
   display: flex;
   justify-content: space-between;
   padding: 16px 0;
-`;
-
-const CardContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
 `;

--- a/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
@@ -4,12 +4,17 @@ import EmptyList from "./EmptyList";
 interface BookmarkListProps {
   isMine: boolean;
   list: Bookmark[];
+  isLoading: boolean;
 }
 
-export default function BookmarkList({ isMine, list }: BookmarkListProps) {
+export default function BookmarkList({
+  isMine,
+  list,
+  isLoading,
+}: BookmarkListProps) {
   return (
     <>
-      {list.length === 0 && (
+      {list.length === 0 && !isLoading && (
         <EmptyList
           message={`입덕한 애니가 없어요.${
             isMine ? " 애니를 추가해 보세요" : ""

--- a/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/BookmarkList.tsx
@@ -1,3 +1,5 @@
+import BookmarkCardSkeleton from "@/features/bookmarks/components/BookmarkCardSkeleton";
+
 import BookmarkCard from "./BookmarkCard";
 import EmptyList from "./EmptyList";
 
@@ -14,6 +16,11 @@ export default function BookmarkList({
 }: BookmarkListProps) {
   return (
     <>
+      {isLoading &&
+        Array.from({ length: 2 }, (_, index) => (
+          <BookmarkCardSkeleton key={index} />
+        ))}
+
       {list.length === 0 && !isLoading && (
         <EmptyList
           message={`입덕한 애니가 없어요.${
@@ -24,6 +31,7 @@ export default function BookmarkList({
           isMine={isMine}
         />
       )}
+
       {list.map((bookmark) => (
         <BookmarkCard
           key={bookmark.animeId}

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -1,4 +1,5 @@
 import ReviewCard from "@/features/reviews/components/ReviewCard";
+import ReviewCardSkeleton from "@/features/reviews/components/ReviewCard/ReviewCardSkeleton";
 import { ReviewListResponse } from "@/features/users/api/profile";
 
 import EmptyList from "./EmptyList";
@@ -16,6 +17,11 @@ export default function ReviewList({
 }: ReviewListProps) {
   return (
     <>
+      {isLoading &&
+        Array.from({ length: 2 }, (_, index) => (
+          <ReviewCardSkeleton key={index} />
+        ))}
+
       {list.length === 0 && !isLoading && (
         <EmptyList
           message={`작성한 리뷰가 없어요.${
@@ -26,6 +32,7 @@ export default function ReviewList({
           isMine={isMine}
         />
       )}
+
       {list.map((review) => (
         <ReviewCard
           key={review.animeId}

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -6,12 +6,17 @@ import EmptyList from "./EmptyList";
 interface ReviewListProps {
   isMine: boolean;
   list: ReviewListResponse[];
+  isLoading: boolean;
 }
 
-export default function ReviewList({ isMine, list }: ReviewListProps) {
+export default function ReviewList({
+  isMine,
+  list,
+  isLoading,
+}: ReviewListProps) {
   return (
     <>
-      {list.length === 0 && (
+      {list.length === 0 && !isLoading && (
         <EmptyList
           message={`작성한 리뷰가 없어요.${
             isMine ? " 리뷰를 작성해 보세요" : ""

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -1,10 +1,11 @@
 import ReviewCard from "@/features/reviews/components/ReviewCard";
+import { ReviewListResponse } from "@/features/users/api/profile";
 
 import EmptyList from "./EmptyList";
 
 interface ReviewListProps {
   isMine: boolean;
-  list: Review[];
+  list: ReviewListResponse[];
 }
 
 export default function ReviewList({ isMine, list }: ReviewListProps) {
@@ -22,11 +23,17 @@ export default function ReviewList({ isMine, list }: ReviewListProps) {
       )}
       {list.map((review) => (
         <ReviewCard
-          key={review.anime.animeId}
+          key={review.animeId}
           isBlock
-          linkTo={`/animes/${review.anime.animeId}`}
+          linkTo={`/animes/${review.animeId}`}
         >
-          <ReviewCard.Anime anime={review.anime} />
+          <ReviewCard.Anime
+            anime={{
+              title: review.title,
+              thumbnail: review.thumbnail,
+              avgScore: review.score,
+            }}
+          />
           <ReviewCard.Comment
             text={review.content}
             isSpoiler={review.isSpoiler}
@@ -38,7 +45,7 @@ export default function ReviewList({ isMine, list }: ReviewListProps) {
             isLike={review.isLike}
             likeCount={review.likeCount}
             reviewId={review.reviewId}
-            animeId={review.anime.animeId}
+            animeId={review.animeId}
             isSpoiler={review.isSpoiler}
             content={review.content}
             score={review.score}

--- a/src/features/users/routes/Profile/TabMenu/index.tsx
+++ b/src/features/users/routes/Profile/TabMenu/index.tsx
@@ -27,8 +27,10 @@ export default function TabMenu({ isMine, memberId }: TabMenuProps) {
     selected: selectedSort,
     bookmarks,
     isLoadingBookmark,
+    isFetchingBookmarkNext,
     reviews,
     isLoadingReview,
+    isFetchingReviewNext,
     handleTabMenuClick,
     SHEET_BUTTONS,
     handleSortClick,
@@ -57,15 +59,25 @@ export default function TabMenu({ isMine, memberId }: TabMenuProps) {
           onClick={handleSortClick}
         />
         {selectedMenu === "한줄리뷰" && (
-          <ReviewList isMine={isMine} list={reviews?.pages ?? []} />
+          <ReviewList
+            isMine={isMine}
+            list={reviews?.pages ?? []}
+            isLoading={isLoadingReview}
+          />
         )}
         {selectedMenu === "입덕애니" && (
-          <BookmarkList isMine={isMine} list={bookmarks?.pages ?? []} />
+          <BookmarkList
+            isMine={isMine}
+            list={bookmarks?.pages ?? []}
+            isLoading={isLoadingBookmark}
+          />
         )}
 
         <Target ref={targetRef} />
 
-        {(isLoadingBookmark || isLoadingReview) && <Loader display="oduck" />}
+        {(isFetchingBookmarkNext || isFetchingReviewNext) && (
+          <Loader display="oduck" />
+        )}
       </ContentContainer>
     </>
   );


### PR DESCRIPTION
## 📝 개요
기존 mock api를 제거했습니다.

## 🚀 변경사항


https://github.com/oduck-team/oduck-client/assets/115006670/0995871d-eaab-4d85-9991-38cb77d47147

1. 선택된 메뉴(한줄리뷰 or 입덕애니)일때만, 목록 fetch 되도록 변경
   - 기존에는 정렬 기준을 변경하면 한줄리뷰와 입덕애니가 함께 fetch 되었습니다.

## 🔗 관련 이슈
#240

## ➕ 기타


