### PR TITLE
fix: 프로필 페이지 user의 애니 개수를 가지고 오도록 변경

### DIFF
--- a/src/features/users/routes/Profile/TabMenu/SortBar.tsx
+++ b/src/features/users/routes/Profile/TabMenu/SortBar.tsx
@@ -2,7 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
 import BottomSheet from "@/components/BottomSheet";
-import useAuth from "@/features/auth/hooks/useAuth";
 import {
   ButtonType,
   SelectedSort,
@@ -22,6 +21,7 @@ import {
 } from "./SortBar.style";
 
 interface SortBarProps {
+  memberId: number;
   selectedMenu: MENU;
   selected: SelectedSort;
   BUTTONS: ButtonType[];
@@ -29,12 +29,12 @@ interface SortBarProps {
 }
 
 export default function SortBar({
+  memberId,
   selectedMenu,
   selected,
   BUTTONS,
   onClick,
 }: SortBarProps) {
-  const { user } = useAuth();
   const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
   const handleBottomSheetToggle = () =>
     setIsBottomSheetVisible((prev) => !prev);
@@ -42,11 +42,11 @@ export default function SortBar({
   const { data } = useQuery({
     queryKey: [
       "profile",
-      user?.memberId,
+      memberId,
       "count",
       selectedMenu === "입덕애니" ? "bookmark" : "review",
     ],
-    queryFn: () => profile.getTabListCount(user?.memberId, selectedMenu),
+    queryFn: () => profile.getTabListCount(memberId, selectedMenu),
   });
 
   return (

--- a/src/features/users/routes/Profile/TabMenu/index.tsx
+++ b/src/features/users/routes/Profile/TabMenu/index.tsx
@@ -53,6 +53,7 @@ export default function TabMenu({ isMine, memberId }: TabMenuProps) {
       </Tab>
       <ContentContainer>
         <SortBar
+          memberId={memberId}
           selectedMenu={selectedMenu}
           selected={selectedSort}
           BUTTONS={SHEET_BUTTONS}


### PR DESCRIPTION
## 📝 개요
프로필 페이지 user의 애니 개수를 가지고 오도록 변경

## 🚀 변경사항
기존 queryFn은 로그인한 사용자의 memberId로 애니 개수를 가지고 오고있었습니다.
프로필 페이지 user의 memberId로 가지고 오도록 변경했습니다.

## 🔗 관련 이슈
#331

## ➕ 기타


