### PR TITLE
feat: 애니 상세페이지 스타일 변경사항 적용 및 내 리뷰 영역 퍼블리싱

### DIFF
--- a/src/components/Progress/index.tsx
+++ b/src/components/Progress/index.tsx
@@ -1,14 +1,12 @@
 import { ComponentProps } from "react";
 
-import { theme } from "@/styles/theme";
-
 import { ProgressContainer } from "./style";
 
 export interface ProgressProps extends ComponentProps<"div"> {
   max?: number;
   min?: number;
   value?: number;
-  color?: keyof typeof theme.colors;
+  color?: string;
   height?: number;
   isRounded?: boolean;
 }

--- a/src/components/Progress/style.ts
+++ b/src/components/Progress/style.ts
@@ -1,6 +1,10 @@
 import styled from "@emotion/styled";
 
+import { theme } from "@/styles/theme";
+
 import { ProgressProps } from ".";
+
+type Color = keyof typeof theme.colors;
 
 export const ProgressContainer = styled.div<ProgressProps>(
   ({ color = "primary", value, height, isRounded, theme }) => ({
@@ -14,7 +18,8 @@ export const ProgressContainer = styled.div<ProgressProps>(
     "& div": {
       height: "100%",
       width: `${value}%`,
-      backgroundColor: theme.colors[color]["60"],
+      backgroundColor:
+        color in theme.colors ? theme.colors[color as Color]["60"] : color,
       borderRadius: isRounded ? "999px" : 0,
     },
   }),

--- a/src/features/animes/routes/Detail/Hero/index.tsx
+++ b/src/features/animes/routes/Detail/Hero/index.tsx
@@ -120,14 +120,7 @@ export default function Hero({
           style={{ margin: "0 auto" }}
         />
         <ReviewRating animeId={id} />
-        <BookmarkContainer
-          style={{
-            width: "100%",
-            paddingTop: "16px",
-            marginTop: "16px",
-            borderTop: "solid 1px #F1F1F1",
-          }}
-        >
+        <BookmarkContainer>
           <BookmarkButton animeId={id} />
         </BookmarkContainer>
       </Actions>

--- a/src/features/animes/routes/Detail/Hero/style.ts
+++ b/src/features/animes/routes/Detail/Hero/style.ts
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import BaseStat from "@/components/Stat";
 
 export const Container = styled.div`
-  padding-bottom: 24px;
+  padding-bottom: 27px;
 `;
 
 export const Banner = styled.div`

--- a/src/features/animes/routes/Detail/PlotAndInfo/index.tsx
+++ b/src/features/animes/routes/Detail/PlotAndInfo/index.tsx
@@ -1,6 +1,8 @@
+import useReadMoreText from "@/hooks/useReadMoreText";
+
 import Section from "../Section";
 
-import { Grid, Plot } from "./style";
+import { Grid, Plot, ReadMoreButton } from "./style";
 
 interface PlotAndInfoProps {
   /** 줄거리 */
@@ -22,10 +24,20 @@ export default function PlotAndInfo({
   voiceActors,
   studios,
 }: PlotAndInfoProps) {
+  const { textRef, isOpen, isShowReadMoreButton, handleReadMoreButtonToggle } =
+    useReadMoreText();
+
   return (
     <Section>
       <h1>줄거리 및 정보</h1>
-      <Plot isExpanded={true}>{summary}</Plot>
+      <Plot ref={textRef} className={isOpen ? undefined : "ellipsis"}>
+        {summary}
+      </Plot>
+      {isShowReadMoreButton && (
+        <ReadMoreButton onClick={handleReadMoreButtonToggle}>
+          {isOpen ? "접기" : "더보기"}
+        </ReadMoreButton>
+      )}
       <Grid>
         <li>
           <span>작가</span>

--- a/src/features/animes/routes/Detail/PlotAndInfo/style.ts
+++ b/src/features/animes/routes/Detail/PlotAndInfo/style.ts
@@ -1,13 +1,9 @@
 import styled from "@emotion/styled";
 
-export const Plot = styled.p<{ isExpanded: boolean }>`
+export const Plot = styled.p`
   display: -webkit-box;
   margin-top: 8px;
-  margin-bottom: 8px;
-  -webkit-line-clamp: ${({ isExpanded }) => (isExpanded ? "none" : "2")};
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  ${({ theme }) => theme.typo["body-3-r"]};
 `;
 
 export const Grid = styled.ul`
@@ -23,12 +19,15 @@ export const Grid = styled.ul`
   }
 
   & > li > span:first-of-type {
-    color: ${({ theme }) => theme.colors.neutral["70"]};
+    color: ${({ theme }) => theme.colors.neutral["60"]};
     padding-right: 8px;
     max-width: 140px;
+    ${({ theme }) => theme.typo["body-3-r"]};
+    letter-spacing: normal;
   }
 
   & > li > span:last-of-type {
     text-align: left;
+    ${({ theme }) => theme.typo["body-3-m"]};
   }
 `;

--- a/src/features/animes/routes/Detail/PlotAndInfo/style.ts
+++ b/src/features/animes/routes/Detail/PlotAndInfo/style.ts
@@ -1,9 +1,24 @@
 import styled from "@emotion/styled";
 
 export const Plot = styled.p`
+  ${({ theme }) => theme.typo["body-3-r"]};
   display: -webkit-box;
   margin-top: 8px;
+  word-break: break-all;
+
+  &.ellipsis {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+`;
+
+export const ReadMoreButton = styled.button`
+  all: unset;
   ${({ theme }) => theme.typo["body-3-r"]};
+  cursor: pointer;
+  display: block;
 `;
 
 export const Grid = styled.ul`

--- a/src/features/animes/routes/Detail/Ratings/index.tsx
+++ b/src/features/animes/routes/Detail/Ratings/index.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from "@emotion/react";
 import { Star } from "@phosphor-icons/react";
 
 import Progress from "@/components/Progress";
@@ -14,7 +15,28 @@ import {
   Grid,
 } from "./style";
 
+// 임시
+type AttractionPointStatics = {
+  [K in keyof AttractionPoint]: number;
+};
+
+const MOCK_STATICS: AttractionPointStatics = {
+  drawing: 100.0,
+  story: 30.0,
+  music: 70.0,
+  character: 45.0,
+  voiceActor: 10.0,
+};
+
 export default function Ratings({ starScoreAvg }: { starScoreAvg: number }) {
+  const ranks = calculateRanks(MOCK_STATICS);
+  const theme = useTheme();
+
+  const progressColor = (val: number) =>
+    theme.colors["primary"][
+      (60 - 10 * val).toString() as keyof typeof theme.colors.primary
+    ];
+
   return (
     <Section>
       <h1>별점</h1>
@@ -27,9 +49,7 @@ export default function Ratings({ starScoreAvg }: { starScoreAvg: number }) {
           value={starScoreAvg * 2}
           readonly
           style={{
-            marginTop: "2px",
-            marginRight: "auto",
-            marginLeft: "auto",
+            margin: "2px auto 0",
           }}
         />
       </AverageRatings>
@@ -38,30 +58,80 @@ export default function Ratings({ starScoreAvg }: { starScoreAvg: number }) {
         <h2>입덕포인트</h2>
         <Grid>
           <AttractionPointLabel>작화</AttractionPointLabel>
-          <Progress isRounded value={100} />
-          <AttractionPointRatio>100%</AttractionPointRatio>
+          <Progress
+            isRounded
+            value={MOCK_STATICS.drawing}
+            color={progressColor(ranks.drawing)}
+          />
+          <AttractionPointRatio>{MOCK_STATICS.drawing}%</AttractionPointRatio>
         </Grid>
         <Grid>
           <AttractionPointLabel>스토리</AttractionPointLabel>
-          <Progress isRounded value={60} style={{ opacity: 0.9 }} />
-          <AttractionPointRatio>100%</AttractionPointRatio>
+          <Progress
+            isRounded
+            value={MOCK_STATICS.story}
+            color={progressColor(ranks.story)}
+          />
+          <AttractionPointRatio>{MOCK_STATICS.story}%</AttractionPointRatio>
         </Grid>
         <Grid>
           <AttractionPointLabel>음악</AttractionPointLabel>
-          <Progress isRounded value={50} style={{ opacity: 0.8 }} />
-          <AttractionPointRatio>100%</AttractionPointRatio>
+          <Progress
+            isRounded
+            value={MOCK_STATICS.music}
+            color={progressColor(ranks.music)}
+          />
+          <AttractionPointRatio>{MOCK_STATICS.music}%</AttractionPointRatio>
         </Grid>
         <Grid>
           <AttractionPointLabel>캐릭터</AttractionPointLabel>
-          <Progress isRounded value={40} style={{ opacity: 0.7 }} />
-          <AttractionPointRatio>100%</AttractionPointRatio>
+          <Progress
+            isRounded
+            value={MOCK_STATICS.character}
+            color={progressColor(ranks.character)}
+          />
+          <AttractionPointRatio>{MOCK_STATICS.character}%</AttractionPointRatio>
         </Grid>
         <Grid>
           <AttractionPointLabel>성우</AttractionPointLabel>
-          <Progress isRounded value={30} style={{ opacity: 0.6 }} />
-          <AttractionPointRatio>100%</AttractionPointRatio>
+          <Progress
+            isRounded
+            value={MOCK_STATICS.voiceActor}
+            color={progressColor(ranks.voiceActor)}
+          />
+          <AttractionPointRatio>
+            {MOCK_STATICS.voiceActor}%
+          </AttractionPointRatio>
         </Grid>
       </AttractionPoint>
     </Section>
   );
+}
+
+function calculateRanks(obj: AttractionPointStatics) {
+  const ranks: AttractionPointStatics = {
+    drawing: 0,
+    story: 0,
+    music: 0,
+    character: 0,
+    voiceActor: 0,
+  };
+
+  const sorted: [string, number][] = Object.entries(obj).sort(
+    (a, b) => b[1] - a[1],
+  );
+
+  let currentRank = 0;
+  let currentScore = sorted[0][1];
+
+  const scores = sorted.map((el) => el[1]);
+  scores.forEach((val, i) => {
+    const key = sorted[i][0] as keyof AttractionPoint;
+    const rank = currentScore <= val ? currentRank : currentRank + 1;
+    ranks[key] = rank;
+    currentRank = rank;
+    currentScore = val;
+  });
+
+  return ranks;
 }

--- a/src/features/animes/routes/Detail/Ratings/style.ts
+++ b/src/features/animes/routes/Detail/Ratings/style.ts
@@ -5,6 +5,7 @@ export const AverageRatings = styled.div`
   flex-direction: column;
   justify-content: center;
   gap: 2px;
+  margin-top: 24px;
 `;
 
 export const AverageRatingsOverview = styled.div`

--- a/src/features/reviews/components/ReviewRating/index.tsx
+++ b/src/features/reviews/components/ReviewRating/index.tsx
@@ -5,13 +5,18 @@ import Rating from "@/components/Rating";
 import useToast from "@/components/Toast/useToast";
 import LoginAlertModal from "@/features/auth/components/LoginAlertModal";
 import useAuth from "@/features/auth/hooks/useAuth";
+import useEvaluation from "@/features/reviews/hook/useEvaluation";
+import useGetEvaluation from "@/features/reviews/hook/useGetEvaluation";
 import useDebounce from "@/hooks/useDebounce";
-
-import useEvaluation from "../../hook/useEvaluation";
-import useGetEvaluation from "../../hook/useGetEvaluation";
+import useReadMoreText from "@/hooks/useReadMoreText";
 
 import ShortReviewModal from "./ShortReviewModal";
-import { ReviewRecommend } from "./style";
+import {
+  ReviewRecommend,
+  EvaluationRecommend,
+  UserReview,
+  Content,
+} from "./style";
 
 interface ReviewRatingProps {
   animeId: number;
@@ -29,6 +34,9 @@ export default function ReviewRating({ animeId }: ReviewRatingProps) {
 
   const { data: evaluation } = useGetEvaluation(animeId);
   const evaluationMutation = useEvaluation({ animeId, hasReview });
+
+  const { textRef, isOpen, isShowReadMoreButton, handleReadMoreButtonToggle } =
+    useReadMoreText();
 
   const handleRate = useDebounce((value: number) => {
     if (!user) {
@@ -55,14 +63,31 @@ export default function ReviewRating({ animeId }: ReviewRatingProps) {
         size="lg"
         onRate={handleRate}
       />
-      {evaluation && (
+      {!evaluation && (
+        <EvaluationRecommend>드래그해서 별점을 남겨보세요</EvaluationRecommend>
+      )}
+      {evaluation && !hasReview && (
         <ReviewRecommend>
           <button onClick={() => setIsReviewModalVisible(true)}>
             한 줄 리뷰를 남겨보세요
           </button>
         </ReviewRecommend>
       )}
-      {hasReview && "TODO: 사용자 리뷰 렌더링 "}
+      {hasReview && (
+        <UserReview>
+          <h3>내 평가</h3>
+          <Content className={isOpen ? undefined : "ellipsis"} ref={textRef}>
+            아주 긴 리뷰 내용 아주 긴 리뷰 내용 아주 긴 리뷰 내용 아주 긴 리뷰
+            내용 아주 긴 리뷰 내용 아주 긴 리뷰 내용 아주 긴 리뷰 내용 아주 긴
+            리뷰 내용 아주 긴 리뷰 내용
+          </Content>
+          {isShowReadMoreButton && (
+            <button onClick={handleReadMoreButtonToggle}>
+              {isOpen ? "접기" : "더보기"}
+            </button>
+          )}
+        </UserReview>
+      )}
 
       <AnimatePresence>
         {isReviewModalVisible && (

--- a/src/features/reviews/components/ReviewRating/style.ts
+++ b/src/features/reviews/components/ReviewRating/style.ts
@@ -17,3 +17,42 @@ export const ReviewRecommend = styled.div`
     cursor: pointer;
   }
 `;
+
+export const EvaluationRecommend = styled.span`
+  ${({ theme }) => theme.typo["micro-r"]};
+  color: ${({ theme }) => theme.colors.neutral["60"]};
+`;
+
+export const UserReview = styled.div`
+  width: 100%;
+  padding: 12px 0px 10px;
+
+  h3 {
+    margin-bottom: 10px;
+  }
+
+  h3,
+  p {
+    ${({ theme }) => theme.typo["body-2-r"]};
+  }
+
+  button {
+    all: unset;
+    ${({ theme }) => theme.typo["body-2-r"]};
+    color: ${({ theme }) => theme.colors["neutral"]["80"]};
+    cursor: pointer;
+  }
+`;
+
+export const Content = styled.p`
+  color: ${({ theme }) => theme.colors["neutral"]["80"]};
+  margin-top: 10px;
+  word-break: break-all;
+
+  &.ellipsis {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+`;

--- a/src/features/users/routes/Profile/AboutMe/index.tsx
+++ b/src/features/users/routes/Profile/AboutMe/index.tsx
@@ -3,12 +3,12 @@ import { useState } from "react";
 
 import Stat from "@/components/Stat";
 import ProfileAvatar from "@/features/users/components/ProfileImageSection/ProfileAvatar";
-import useIntroduceReadMore from "@/features/users/hooks/useIntroduceReadMore";
+import useReadMoreText from "@/hooks/useReadMoreText";
 
 import ProfileImageSection from "../../../components/ProfileImageSection";
 
 import StatModal from "./StatModal";
-import { Introduce, NickName, SeeMoreButton, StatContainer } from "./style";
+import { Introduce, NickName, ReadMoreButton, StatContainer } from "./style";
 
 interface AboutMeProps {
   profile: Profile;
@@ -17,12 +17,8 @@ interface AboutMeProps {
 export default function AboutMe({
   profile: { activity, backgroundImage, description, isMine, name, thumbnail },
 }: AboutMeProps) {
-  const {
-    introduceRef,
-    isOpen,
-    isShowReadMoreButton,
-    handleSeeMoreButtonToggle,
-  } = useIntroduceReadMore();
+  const { textRef, isOpen, isShowReadMoreButton, handleReadMoreButtonToggle } =
+    useReadMoreText();
   const [isStatModalVisible, setIsStatModalVisible] = useState(false);
   const handleStatModalToggle = () => setIsStatModalVisible((prev) => !prev);
 
@@ -44,14 +40,14 @@ export default function AboutMe({
       </ProfileImageSection>
 
       <NickName>{name}</NickName>
-      <Introduce className={isOpen ? undefined : "ellipsis"} ref={introduceRef}>
+      <Introduce className={isOpen ? undefined : "ellipsis"} ref={textRef}>
         {description}
       </Introduce>
 
       {isShowReadMoreButton && (
-        <SeeMoreButton onClick={handleSeeMoreButtonToggle}>
+        <ReadMoreButton onClick={handleReadMoreButtonToggle}>
           {isOpen ? "접기" : "더보기"}
-        </SeeMoreButton>
+        </ReadMoreButton>
       )}
 
       <StatContainer onClick={handleStatModalToggle}>

--- a/src/features/users/routes/Profile/AboutMe/style.ts
+++ b/src/features/users/routes/Profile/AboutMe/style.ts
@@ -23,7 +23,7 @@ export const Introduce = styled.p`
   }
 `;
 
-export const SeeMoreButton = styled.button`
+export const ReadMoreButton = styled.button`
   ${({ theme }) => theme.typo["body-3-r"]};
   color: ${({ theme }) => theme.colors.neutral[50]};
   position: relative;

--- a/src/hooks/useReadMoreText.ts
+++ b/src/hooks/useReadMoreText.ts
@@ -2,34 +2,33 @@ import { useState, useEffect, useRef } from "react";
 
 import useDebounce from "@/hooks/useDebounce";
 
-export default function useIntroduceReadMore() {
-  const introduceRef = useRef<HTMLParagraphElement>(null);
+export default function useReadMoreText() {
+  const textRef = useRef<HTMLParagraphElement>(null);
   const [isShowReadMoreButton, setIsShowReadMoreButton] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleSeeMoreButtonToggle = () => setIsOpen((prev) => !prev);
+  const handleReadMoreButtonToggle = () => setIsOpen((prev) => !prev);
 
   /** 더보기/접기 버튼 렌더링 결정 */
   const checkReadMoreButtonAvailability = useDebounce(() => {
-    if (introduceRef.current) {
-      // 자기소개 element의 ellipsis class 여부 저장
-      const hadEllipsisClass =
-        introduceRef.current.classList.contains("ellipsis");
+    if (textRef.current) {
+      // text element의 ellipsis class 여부 저장
+      const hadEllipsisClass = textRef.current.classList.contains("ellipsis");
 
-      // 처음 저장한 자기소개 element에 ellipsis 적용되어 있지 않다면 (화면에 접기 버튼 렌더링)
-      // 자기소개 element에 ellipsis class 추가
+      // 처음 저장한 text element에 ellipsis 적용되어 있지 않다면 (화면에 접기 버튼 렌더링)
+      // text element에 ellipsis class 추가
       if (!hadEllipsisClass) {
-        introduceRef.current.classList.add("ellipsis");
+        textRef.current.classList.add("ellipsis");
       }
 
       // 더보기/접기 버튼 렌더링 결정
       setIsShowReadMoreButton(
-        introduceRef.current.clientHeight !== introduceRef.current.scrollHeight,
+        textRef.current.clientHeight !== textRef.current.scrollHeight,
       );
 
       // 이전에 추가한 ellipsis class 제거하여 원래대로 돌아감
       if (!hadEllipsisClass) {
-        introduceRef.current.classList.remove("ellipsis");
+        textRef.current.classList.remove("ellipsis");
       }
     }
   }, 100);
@@ -44,9 +43,9 @@ export default function useIntroduceReadMore() {
   }, [checkReadMoreButtonAvailability]);
 
   return {
-    introduceRef,
+    textRef,
     isOpen,
     isShowReadMoreButton,
-    handleSeeMoreButtonToggle,
+    handleReadMoreButtonToggle,
   };
 }


### PR DESCRIPTION
## 📝 개요

애니 상세페이지 스타일 변경사항 적용 및 내 리뷰 영역 퍼블리싱

- 상세페이지 폰트 크기 및 간격 변경 사항 적용

- 별점 미평가시 권유 메시지 추가

<img src="https://github.com/oduck-team/oduck-client/assets/80813703/f16e2b10-4cf0-448d-abd2-55fe0f62396b" width="300px"/>

<br/><br/>

- 내가 남긴 리뷰 영역 퍼블리싱 및 줄거리 더보기 추가

https://github.com/oduck-team/oduck-client/assets/80813703/4af8700f-4b05-4f01-a7d0-af67ccfc33b4

<br/>

- 입덕포인트 통계 값에 따라 색상 설정

<img src="https://github.com/oduck-team/oduck-client/assets/80813703/f762d5b1-77fa-48d7-ba3d-bc68f9209b63" width="500px"/>

(실제 데이터 반영 및 mock 데이터 제거는 #303 에서 바로 이어 작업하겠습니다.)


## 🚀 변경사항

- Progress 컴포넌트 색상 props 타입 변경
- 자기소개 더보기에 사용되었던 `useIntroduceMore` hook을 공통 hook `useReadMoreText`로 변경, 변수명 일부 수정

## 🔗 관련 이슈

#338

## ➕ 기타
