### PR TITLE
fix: 애니 리스트 페이지 무한 스크롤 발생 시, 스크롤 초기화 버그 수정

### DIFF
--- a/src/features/animes/hooks/useAnimes.ts
+++ b/src/features/animes/hooks/useAnimes.ts
@@ -4,6 +4,8 @@ import { useApi } from "@/hooks/useApi";
 
 import { GetAnimesQuery } from "../api/AnimeApi";
 
+import { REQUEST_SIZE } from "./useFilterAnimes";
+
 interface UseAnimes {
   /** 자동 fetch 여부 */
   autoFetch?: boolean;
@@ -14,14 +16,18 @@ interface UseAnimes {
 
 export default function useAnimes({
   autoFetch = true,
-  queryParams = { size: 10, sort: "LATEST" },
+  queryParams = { size: REQUEST_SIZE, sort: "LATEST" },
 }: UseAnimes) {
   const { animeApi } = useApi();
 
   return useInfiniteQuery({
     queryKey: ["animes", queryParams],
     queryFn: ({ pageParam }) =>
-      animeApi.getList({ size: 2, ...queryParams, cursor: pageParam }),
+      animeApi.getList({
+        size: REQUEST_SIZE,
+        ...queryParams,
+        cursor: pageParam,
+      }),
     getNextPageParam: (lastPage) => lastPage.cursor || undefined,
     select: (data) => ({
       pages: data.pages.flatMap((page) => page.items),

--- a/src/features/animes/hooks/useFilterAnimes.ts
+++ b/src/features/animes/hooks/useFilterAnimes.ts
@@ -30,7 +30,7 @@ export type AllFilterTypes =
   | StatusFilter
   | EpisodeCountFilter;
 
-const REQUEST_SIZE = 10; // 요청당 개수
+export const REQUEST_SIZE = 10; // 요청당 개수
 
 /**
  * @description 애니메이션 목록을 필터와 함께 조회합니다

--- a/src/features/animes/routes/List/index.tsx
+++ b/src/features/animes/routes/List/index.tsx
@@ -6,6 +6,7 @@ import Button from "@/components/Button";
 import Empty from "@/components/Error/Empty";
 import Head from "@/components/Head";
 import Header from "@/components/Layout/Header";
+import Loader from "@/components/Loader";
 import { TabItem } from "@/components/Tabs";
 import AnimeCard from "@/features/animes/components/AnimeCard";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
@@ -83,18 +84,16 @@ export default function AnimeList() {
           onChange={(value) => changeSort(value as AnimeSort)}
         />
         <Content>
-          {(animesQuery.isLoading || animesQuery.isFetching) &&
+          {animesQuery.isLoading &&
             Array.from({ length: 7 }, (_, i) => (
               <GridAnimeCardSkeleton key={i} />
             ))}
 
-          {!animesQuery.isLoading &&
-            !animesQuery.isFetching &&
-            animesQuery.data?.pages.length === 0 && (
-              <Empty message="애니가 없어요" />
-            )}
+          {animesQuery.data?.pages.length === 0 && (
+            <Empty message="애니가 없어요" />
+          )}
 
-          {!animesQuery.isLoading && !animesQuery.isFetching && (
+          {animesQuery.data && (
             <>
               {animesQuery.data?.pages.map((item) => (
                 <AnimeCard
@@ -103,9 +102,12 @@ export default function AnimeList() {
                   onClick={() => navigate(`/animes/${item.id}`)}
                 />
               ))}
-              <div ref={observeRef}></div>
             </>
           )}
+
+          <div ref={observeRef} />
+
+          {animesQuery.isFetchingNextPage && <Loader display="oduck" />}
         </Content>
         <Filter
           isVisible={bottomSheetVisible}


### PR DESCRIPTION
## 📝 개요
애니 리스트 페이지 무한 스크롤 발생 시, 스크롤 초기화 버그 수정

## 🚀 변경사항
- 스크롤 초기화 버그 수정
- Skeleton, Empty, AnimeCard 렌더링 조건 변경
- 무한스크롤 Loader 컴포넌트 추가

## 🔗 관련 이슈
#344

## ➕ 기타


