### PR TITLE
feat: 입덕포인트 수정 및 통계 조회 구현

### DIFF
--- a/src/features/animes/api/AnimeApi.ts
+++ b/src/features/animes/api/AnimeApi.ts
@@ -59,6 +59,10 @@ type ListAnimeResponse = CursorPage<{
   starScoreAvg: number;
 }>;
 
+export type AttractionPointStatics = {
+  [K in keyof AttractionPoint]: number;
+};
+
 export type TOP10ListResponse = Pick<Anime, "title" | "thumbnail"> & {
   animeId: number;
   genres: string[];
@@ -90,6 +94,10 @@ export default class AnimeApi {
 
   getAverageRating(id: number) {
     return get<{ starRatingAvg: number }>(`/animes/${id}/ratings/average`);
+  }
+
+  getAttractionPoint(id: number) {
+    return get<AttractionPointStatics>(`/attraction-points/animes/${id}`);
   }
 
   async getTOP10List(): Promise<TOP10ListResponse[]> {

--- a/src/features/animes/hooks/useAnime.ts
+++ b/src/features/animes/hooks/useAnime.ts
@@ -4,6 +4,8 @@ import useAuth from "@/features/auth/hooks/useAuth";
 import { useApi } from "@/hooks/useApi";
 import { calcStarRatingAvg } from "@/utils/common";
 
+import { AttractionPointStatics } from "../api/AnimeApi";
+
 export default function useAnime(animeId: number) {
   const { animeApi } = useApi();
   const { user } = useAuth();
@@ -13,6 +15,11 @@ export default function useAnime(animeId: number) {
     queryFn: () => animeApi.getAverageRating(animeId),
   });
 
+  const { data: statics } = useQuery({
+    queryKey: ["attraction", animeId],
+    queryFn: () => animeApi.getAttractionPoint(animeId),
+  });
+
   const { data: anime, isLoading } = useQuery({
     queryKey: ["anime", animeId, user?.memberId],
     queryFn: () => animeApi.getById(animeId),
@@ -20,5 +27,15 @@ export default function useAnime(animeId: number) {
 
   const starRatingAvg = calcStarRatingAvg(data?.starRatingAvg);
 
-  return { starRatingAvg, anime, isLoading };
+  // 입덕포인트 통계 값 소수점 한 자리 밑으로 자른 후 반환
+  const attractionStatics =
+    statics &&
+    (Object.fromEntries(
+      Object.entries(statics).map(([key, value]) => [
+        key,
+        Math.floor(value * 10) / 10,
+      ]),
+    ) as AttractionPointStatics);
+
+  return { starRatingAvg, attractionStatics, anime, isLoading };
 }

--- a/src/features/animes/hooks/useAnime.ts
+++ b/src/features/animes/hooks/useAnime.ts
@@ -16,7 +16,7 @@ export default function useAnime(animeId: number) {
   });
 
   const { data: statics } = useQuery({
-    queryKey: ["attraction", animeId],
+    queryKey: ["attraction", animeId, "statics"],
     queryFn: () => animeApi.getAttractionPoint(animeId),
   });
 

--- a/src/features/animes/routes/Detail/Ratings/index.tsx
+++ b/src/features/animes/routes/Detail/Ratings/index.tsx
@@ -2,6 +2,7 @@ import { Star } from "@phosphor-icons/react";
 
 import Progress from "@/components/Progress";
 import Rating from "@/components/Rating";
+import { AttractionPointStatics } from "@/features/animes/api/AnimeApi";
 
 import Section from "../Section";
 
@@ -14,7 +15,12 @@ import {
   Grid,
 } from "./style";
 
-export default function Ratings({ starScoreAvg }: { starScoreAvg: number }) {
+interface Props {
+  starScoreAvg: number;
+  statics: AttractionPointStatics;
+}
+
+export default function Ratings({ starScoreAvg, statics }: Props) {
   return (
     <Section>
       <h1>별점</h1>
@@ -38,28 +44,36 @@ export default function Ratings({ starScoreAvg }: { starScoreAvg: number }) {
         <h2>입덕포인트</h2>
         <Grid>
           <AttractionPointLabel>작화</AttractionPointLabel>
-          <Progress isRounded value={100} />
-          <AttractionPointRatio>100%</AttractionPointRatio>
+          <Progress isRounded value={statics.drawing} />
+          <AttractionPointRatio>{statics.drawing}%</AttractionPointRatio>
         </Grid>
         <Grid>
           <AttractionPointLabel>스토리</AttractionPointLabel>
-          <Progress isRounded value={60} style={{ opacity: 0.9 }} />
-          <AttractionPointRatio>100%</AttractionPointRatio>
+          <Progress isRounded value={statics.story} style={{ opacity: 0.9 }} />
+          <AttractionPointRatio>{statics.story}%</AttractionPointRatio>
         </Grid>
         <Grid>
           <AttractionPointLabel>음악</AttractionPointLabel>
-          <Progress isRounded value={50} style={{ opacity: 0.8 }} />
-          <AttractionPointRatio>100%</AttractionPointRatio>
+          <Progress isRounded value={statics.music} style={{ opacity: 0.8 }} />
+          <AttractionPointRatio>{statics.music}%</AttractionPointRatio>
         </Grid>
         <Grid>
           <AttractionPointLabel>캐릭터</AttractionPointLabel>
-          <Progress isRounded value={40} style={{ opacity: 0.7 }} />
-          <AttractionPointRatio>100%</AttractionPointRatio>
+          <Progress
+            isRounded
+            value={statics.character}
+            style={{ opacity: 0.7 }}
+          />
+          <AttractionPointRatio>{statics.character}%</AttractionPointRatio>
         </Grid>
         <Grid>
           <AttractionPointLabel>성우</AttractionPointLabel>
-          <Progress isRounded value={30} style={{ opacity: 0.6 }} />
-          <AttractionPointRatio>100%</AttractionPointRatio>
+          <Progress
+            isRounded
+            value={statics.voiceActor}
+            style={{ opacity: 0.6 }}
+          />
+          <AttractionPointRatio>{statics.voiceActor}%</AttractionPointRatio>
         </Grid>
       </AttractionPoint>
     </Section>

--- a/src/features/animes/routes/Detail/index.tsx
+++ b/src/features/animes/routes/Detail/index.tsx
@@ -18,6 +18,7 @@ export default function AnimeDetail() {
 
   const {
     starRatingAvg,
+    attractionStatics,
     anime,
     isLoading: isAnimeLoading,
   } = useAnime(Number(animeId));
@@ -43,18 +44,17 @@ export default function AnimeDetail() {
           {/* TODO: 평점 */}
           <Hero {...anime} starScoreAvg={starRatingAvg} />
           <SectionDivider />
-
           {/* 줄거리 및 정보 */}
           <PlotAndInfo
             {...anime}
             voiceActors={anime.voiceActors.map((actor) => actor.name)}
           />
           <SectionDivider />
-
           {/* 평점 */}
-          <Ratings starScoreAvg={starRatingAvg} />
+          {attractionStatics && (
+            <Ratings starScoreAvg={starRatingAvg} statics={attractionStatics} />
+          )}
           <SectionDivider />
-
           {/* 리뷰 목록 */}
           <Reviews
             reviews={reviews?.pages ?? []}

--- a/src/features/reviews/api/review.ts
+++ b/src/features/reviews/api/review.ts
@@ -154,6 +154,17 @@ export default class ReviewApi {
     });
   }
 
+  /** @description 입덕 포인트 수정 */
+  async updateAttractionPoint(
+    animeId: number,
+    attractionElements: AttractionType[],
+  ) {
+    return patch(`/attraction-points`, {
+      animeId,
+      attractionElements,
+    });
+  }
+
   /** @description 입덕 포인트 존재 여부 조회 */
   async getUserAttractionPointStatus(animeId: number) {
     return get<{ isAttractionPoint: boolean }>(`/attraction-points/${animeId}`);

--- a/src/features/reviews/components/ReviewCard/ReviewComent.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewComent.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { ReviewComentContainer } from "./ReviewComent.style";
 import SpoilerComment from "./SpoilerComment";
@@ -18,6 +18,11 @@ export default function ReviewComent({
 }: ReviewTextProps) {
   const [isSpoilerComment, setIsSpoilerComment] = useState(isSpoiler);
   const handleShowSpoilerClick = () => setIsSpoilerComment(false);
+
+  // 리뷰 수정에서 스포일러 여부 수정 시 바로 반영되도록 함
+  useEffect(() => {
+    setIsSpoilerComment(isSpoiler);
+  }, [isSpoiler]);
 
   return (
     <ReviewComentContainer textSize={textSize}>

--- a/src/features/reviews/hook/useAttractionPoint.ts
+++ b/src/features/reviews/hook/useAttractionPoint.ts
@@ -26,13 +26,16 @@ export default function useAttractionPoint(animeId: number) {
     queryFn: () => reviewApi.getUserAttractionPointStatus(animeId),
   });
 
-  // 입덕 포인트 추가
-  const addAttraction = useMutation({
-    mutationFn: (attractions: AttractionType[]) =>
-      reviewApi.addAttractionPoint(animeId, attractions),
+  // 입덕 포인트 추가/수정
+  const attractionMutation = useMutation({
+    mutationFn: (attractions: AttractionType[]) => {
+      if (!status?.isAttractionPoint)
+        return reviewApi.addAttractionPoint(animeId, attractions);
+      return reviewApi.updateAttractionPoint(animeId, attractions);
+    },
     onSuccess: () => {
+      // 사용자 입덕 포인트, 입덕 포인트 존재 여부, 입덕 포인트 통계 무효화
       queryClient.invalidateQueries(["attraction", animeId]);
-      // TODO: 애니 입덕 포인트 통계 query 무효화
     },
     onError: (error) => {
       if (error instanceof AxiosError && error.response?.status) {
@@ -49,5 +52,5 @@ export default function useAttractionPoint(animeId: number) {
     },
   });
 
-  return { userAttraction, status, addAttraction };
+  return { userAttraction, status, attractionMutation };
 }

--- a/src/features/reviews/hook/useReviewForm.tsx
+++ b/src/features/reviews/hook/useReviewForm.tsx
@@ -26,28 +26,28 @@ export default function useReviewForm(
   const { user } = useAuth();
   const { addReview, updateReview } = useReview(animeId, onReview);
 
-  const { userAttraction, addAttraction, status } = useAttractionPoint(animeId);
+  const { userAttraction, attractionMutation } = useAttractionPoint(animeId);
 
   const toast = useToast();
 
   const [form, setForm] = useState<ReviewForm>({
     content: userReviewData?.content ?? "",
     isSpoiler: userReviewData?.isSpoiler ?? false,
-    character: userAttraction?.character ?? false,
     drawing: userAttraction?.drawing ?? false,
     story: userAttraction?.story ?? false,
-    voiceActor: userAttraction?.voiceActor ?? false,
     music: userAttraction?.music ?? false,
+    character: userAttraction?.character ?? false,
+    voiceActor: userAttraction?.voiceActor ?? false,
   });
 
   useEffect(() => {
     setForm((prev) => ({
       ...prev,
-      character: userAttraction?.character ?? false,
       drawing: userAttraction?.drawing ?? false,
       story: userAttraction?.story ?? false,
-      voiceActor: userAttraction?.voiceActor ?? false,
       music: userAttraction?.music ?? false,
+      character: userAttraction?.character ?? false,
+      voiceActor: userAttraction?.voiceActor ?? false,
     }));
   }, [userAttraction]);
 
@@ -78,42 +78,51 @@ export default function useReviewForm(
       return;
     }
 
-    // 체크한 입덕 포인트
-    const selectedAttraction = Object.keys(form)
-      .filter(
-        (key) =>
-          form[key as keyof ReviewForm] === true &&
-          !["content, isSpoiler"].includes(key),
-      )
+    const { content, isSpoiler, ...attraction } = form;
+    const isReviewChanged = !userReviewData
+      ? true
+      : userReviewData.content !== content ||
+        userReviewData.isSpoiler !== isSpoiler;
+
+    // 체크한 입덕포인트
+    const selectedAttraction = Object.keys(attraction)
+      .filter((key) => attraction[key as keyof AttractionPoint] === true)
       .map((key) =>
         key === "voiceActor" ? "VOICE_ACTOR" : key.toUpperCase(),
       ) as AttractionType[];
 
-    console.log("입덕 포인트: ", selectedAttraction);
+    const isAttractionChanged = !userAttraction
+      ? true
+      : Object.entries(userAttraction).toString() !==
+        Object.entries({ ...attraction }).toString();
 
-    // 입덕 포인트 추가: 체크된 입덕 포인트가 있는 경우에만 요청
-    if (selectedAttraction.length !== 0 && !status?.isAttractionPoint) {
-      addAttraction.mutate(selectedAttraction);
-    }
+    // 입덕포인트 추가/수정: 변경된 값이 있는 경우에만 수행
+    if (selectedAttraction.length !== 0 && isAttractionChanged)
+      attractionMutation.mutate(selectedAttraction, {
+        onSuccess: () => {
+          // 리뷰 내용을 제외한 입덕포인트만 변경된 경우 toast 생성
+          if (!isReviewChanged)
+            toast.success({
+              message: "입덕포인트가 수정되었어요.",
+            });
+        },
+      });
 
-    // TODO: 입덕 포인트 수정
+    const review = {
+      name: user?.name ?? "",
+      animeId,
+      hasSpoiler: isSpoiler,
+      content: content,
+    };
 
     // 리뷰 수정
     if (userReviewData) {
       // 내용에 변화가 있을 경우에만 요청
-      if (
-        userReviewData.content !== form.content ||
-        userReviewData.isSpoiler !== form.isSpoiler
-      )
+      if (isReviewChanged)
         updateReview.mutate(
           {
             reviewId: userReviewData.reviewId,
-            review: {
-              name: user?.name ?? "",
-              animeId,
-              hasSpoiler: form.isSpoiler,
-              content: form.content,
-            },
+            review,
           },
           {
             onSuccess: () => {
@@ -127,23 +136,15 @@ export default function useReviewForm(
       else onReview();
     } else {
       // 리뷰 추가
-      addReview.mutate(
-        {
-          name: user?.name ?? "",
-          animeId,
-          hasSpoiler: form.isSpoiler,
-          content: form.content,
+      addReview.mutate(review, {
+        onSuccess: () => {
+          toast.success({
+            message: "리뷰가 등록되었어요.",
+            buttonText: "내 모든 리뷰 보러 가기",
+            onClickButton: () => navigate("/profile"),
+          });
         },
-        {
-          onSuccess: () => {
-            toast.success({
-              message: "리뷰가 등록되었어요.",
-              buttonText: "내 모든 리뷰 보러 가기",
-              onClickButton: () => navigate("/profile"),
-            });
-          },
-        },
-      );
+      });
     }
   }, DEBOUNCE_DELAY);
 

--- a/src/features/reviews/hook/useReviewForm.tsx
+++ b/src/features/reviews/hook/useReviewForm.tsx
@@ -101,10 +101,12 @@ export default function useReviewForm(
       attractionMutation.mutate(selectedAttraction, {
         onSuccess: () => {
           // 리뷰 내용을 제외한 입덕포인트만 변경된 경우 toast 생성
-          if (!isReviewChanged)
+          if (!isReviewChanged) {
             toast.success({
               message: "입덕포인트가 수정되었어요.",
             });
+            onReview();
+          }
         },
       });
 
@@ -132,8 +134,6 @@ export default function useReviewForm(
             },
           },
         );
-      // 모달 닫기
-      else onReview();
     } else {
       // 리뷰 추가
       addReview.mutate(review, {
@@ -146,6 +146,8 @@ export default function useReviewForm(
         },
       });
     }
+    // 변경 사항이 없을 때 모달 닫기
+    if (!isAttractionChanged && !isReviewChanged) onReview();
   }, DEBOUNCE_DELAY);
 
   return {


### PR DESCRIPTION
## 📝 개요

입덕포인트 수정 및 통계 조회 구현

- 입덕포인트만 수정 시 (toast 메시지: 입덕포인트가 수정되었어요.)

https://github.com/oduck-team/oduck-client/assets/80813703/20ed9948-6583-49af-b2c0-fbdc4bae9959

<br/>

- 입덕포인트와 리뷰 내용/스포여부 함께 수정 시 (toast 메시지: 리뷰가 수정되었어요.)

https://github.com/oduck-team/oduck-client/assets/80813703/6975409e-929c-4760-9de6-209c48702fb2



## 🚀 변경사항

- 스포일러 여부와 입덕포인트를 함께 설정 시 스포일러 여부가 attractionElements 배열에 함께 포함되는 버그 수정
- 스포일러 여부 변경 시 스포일러 박스(SpoilerComment) 렌더링에 바로 반영되지 않는 버그 수정

## 🔗 관련 이슈

#303

## ➕ 기타

- 개발 환경에서는 입덕포인트에 **'작화'** 포함 시 500 오류가 뜹니다. 배포 환경은 잘 동작합니다.
- 입덕포인트 수정의 경우 
```
기존: 캐릭터, 작화, 성우
수정 후: 캐릭터, 음악
```
위와 같이 변화가 있을 때 patch 요청에 생성과 같은 형태로 **[캐릭터, 음악]** 이 들어가게 되는데
현재 서버 쪽에서는 변화가 있는 요소 **[작화, 성우, 음악]** 만 받는 걸로 되어있습니다.
하니님께서 프론트 방식대로 수정해주신다고 하셔서 이대로 올립니다!

아직 서버 쪽 수정 반영이 되지 않아서 현재는 수정 요청에 기존 값에 포함된 요소를 포함하면 잘 동작하지 않습니다.
수정 반영 후에 다시 테스트가 필요합니다!

<br/>
 

