### PR TITLE
로그인 페이지 높이 수정 및 mock api를 이용한 리뷰 삭제 구현

### DIFF
--- a/src/features/animes/routes/Detail/Reviews/index.tsx
+++ b/src/features/animes/routes/Detail/Reviews/index.tsx
@@ -1,8 +1,8 @@
 import Chip from "@/components/Chip";
+import Loader from "@/components/Loader";
 import useAuth from "@/features/auth/hooks/useAuth";
-import { ReviewInfo } from "@/features/reviews/api/review";
 import ReviewCard from "@/features/reviews/components/ReviewCard";
-import { ReviewSortOption } from "@/features/reviews/hook/useGetAnimeReviews";
+import useGetAnimeReviews from "@/features/reviews/hook/useGetAnimeReviews";
 
 import LoadingReviews from "../LoadingReviews";
 
@@ -10,78 +10,83 @@ import EmptyReview from "./Empty";
 import { Section, TotalReviews } from "./style";
 
 interface Props {
-  reviews: ReviewInfo[];
-  isLoading: boolean;
   totalReviewCount: number;
-  handleChipClick: (i: number) => void;
-  sortOptions: ReviewSortOption[];
-  selectedOption: ReviewSortOption;
+  animeId: number;
 }
 
-export default function Reviews({
-  reviews,
-  isLoading,
-  totalReviewCount,
-  sortOptions,
-  selectedOption,
-  handleChipClick,
-}: Props) {
+export default function Reviews({ totalReviewCount, animeId }: Props) {
   const { user } = useAuth();
 
+  const {
+    reviews: data,
+    isFetchingNextPage,
+    isLoading,
+    targetRef,
+    SORT_OPTION,
+    selectedSortOption,
+    handleChipClick,
+  } = useGetAnimeReviews(Number(animeId));
+
+  const reviews = data?.pages ?? [];
+
   return (
-    <Section>
-      <h1>한 줄 리뷰</h1>
-      {!isLoading && reviews.length === 0 && <EmptyReview />}
-      {(isLoading || (!isLoading && reviews.length !== 0)) && (
-        <div>
-          <TotalReviews>
-            총 {totalReviewCount.toLocaleString()}명이 리뷰를 남겨 주셨어요
-          </TotalReviews>
+    <>
+      <Section>
+        <h1>한 줄 리뷰</h1>
+        {!isLoading && reviews.length === 0 && <EmptyReview />}
+        {(isLoading || (!isLoading && reviews.length !== 0)) && (
+          <div>
+            <TotalReviews>
+              총 {totalReviewCount.toLocaleString()}명이 리뷰를 남겨 주셨어요
+            </TotalReviews>
+            <ul>
+              {SORT_OPTION.map((option, i) => (
+                <li key={option.label}>
+                  <Chip
+                    variant="selectable"
+                    onClick={() => handleChipClick(i)}
+                    active={selectedSortOption.label === option.label}
+                  >
+                    {option.label}
+                  </Chip>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {isLoading && <LoadingReviews />}
+        {!isLoading && reviews.length !== 0 && (
           <ul>
-            {sortOptions.map((option, i) => (
-              <li key={option.label}>
-                <Chip
-                  variant="selectable"
-                  onClick={() => handleChipClick(i)}
-                  active={selectedOption.label === option.label}
-                >
-                  {option.label}
-                </Chip>
+            {reviews.map((review, i) => (
+              <li key={review.reviewId}>
+                <ReviewCard border={i === 0 ? "top" : "bottom"}>
+                  <ReviewCard.UserRating
+                    user={{ name: review.name, thumbnail: review.thumbnail }}
+                    rating={review.score}
+                  />
+                  <ReviewCard.Comment
+                    text={review.content}
+                    textSize="sm"
+                    isSpoiler={review.isSpoiler}
+                  />
+                  <ReviewCard.ActionBar
+                    isMine={user?.name === review.name}
+                    likeCount={review.likeCount}
+                    createdAt={review.createdAt}
+                    reviewId={review.reviewId}
+                    animeId={review.animeId}
+                    isSpoiler={review.isSpoiler}
+                    content={review.content}
+                    score={review.score}
+                  />
+                </ReviewCard>
               </li>
             ))}
           </ul>
-        </div>
-      )}
-      {isLoading && <LoadingReviews />}
-      {!isLoading && reviews.length !== 0 && (
-        <ul>
-          {reviews.map((review, i) => (
-            <li key={review.reviewId}>
-              <ReviewCard border={i === 0 ? "top" : "bottom"}>
-                <ReviewCard.UserRating
-                  user={{ name: review.name, thumbnail: review.thumbnail }}
-                  rating={review.score}
-                />
-                <ReviewCard.Comment
-                  text={review.content}
-                  textSize="sm"
-                  isSpoiler={review.isSpoiler}
-                />
-                <ReviewCard.ActionBar
-                  isMine={user?.name === review.name}
-                  likeCount={review.likeCount}
-                  createdAt={review.createdAt}
-                  reviewId={review.reviewId}
-                  animeId={review.animeId}
-                  isSpoiler={review.isSpoiler}
-                  content={review.content}
-                  score={review.score}
-                />
-              </ReviewCard>
-            </li>
-          ))}
-        </ul>
-      )}
-    </Section>
+        )}
+      </Section>
+      <div ref={targetRef}></div>
+      {isFetchingNextPage && <Loader display="oduck" />}
+    </>
   );
 }

--- a/src/features/animes/routes/Detail/index.tsx
+++ b/src/features/animes/routes/Detail/index.tsx
@@ -1,9 +1,10 @@
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 
+import ErrorBoundary from "@/components/Error/ErrorBoundary";
 import Head from "@/components/Head";
 import Loader from "@/components/Loader";
 import SectionDivider from "@/components/SectionDivider";
-import useGetAnimeReviews from "@/features/reviews/hook/useGetAnimeReviews";
 
 import useAnime from "../../hooks/useAnime";
 
@@ -15,6 +16,7 @@ import { AnimeDetailContainer } from "./style";
 
 export default function AnimeDetail() {
   const { id: animeId } = useParams();
+  const { reset } = useQueryErrorResetBoundary();
 
   const {
     starRatingAvg,
@@ -22,15 +24,6 @@ export default function AnimeDetail() {
     anime,
     isLoading: isAnimeLoading,
   } = useAnime(Number(animeId));
-
-  const {
-    reviews,
-    isLoading,
-    targetRef,
-    SORT_OPTION,
-    selectedSortOption,
-    handleChipClick,
-  } = useGetAnimeReviews(Number(animeId));
 
   if (isAnimeLoading) {
     return <Loader />;
@@ -56,16 +49,12 @@ export default function AnimeDetail() {
           )}
           <SectionDivider />
           {/* 리뷰 목록 */}
-          <Reviews
-            reviews={reviews?.pages ?? []}
-            isLoading={isLoading}
-            totalReviewCount={anime.reviewCount}
-            sortOptions={SORT_OPTION}
-            selectedOption={selectedSortOption}
-            handleChipClick={handleChipClick}
-          />
-          <div ref={targetRef}></div>
-          {isLoading && <Loader display="oduck" />}
+          <ErrorBoundary onReset={reset}>
+            <Reviews
+              animeId={Number(animeId)}
+              totalReviewCount={anime.reviewCount}
+            />
+          </ErrorBoundary>
         </AnimeDetailContainer>
       </>
     );

--- a/src/features/auth/routes/Login/style.ts
+++ b/src/features/auth/routes/Login/style.ts
@@ -5,7 +5,8 @@ export const Main = styled.main`
   position: relative;
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: calc(100vh - 60px); // dvh를 지원하지 않는 브라우저 대응
+  height: calc(100dvh - 60px);
   margin: 0 auto;
   padding-left: 1rem;
   padding-right: 1rem;

--- a/src/features/reviews/api/review.ts
+++ b/src/features/reviews/api/review.ts
@@ -49,6 +49,13 @@ export default class ReviewApi {
     return patch(`/short-reviews/${reviewId}`, review);
   }
 
+  /** @description 리뷰 삭제 요청 */
+  async deleteReview(reviewId: number) {
+    return Promise.resolve(console.log(`${reviewId} 삭제완료`));
+    // TODO: 실제 api 반영
+    // return del(`/short-reviews/${reviewId}`);
+  }
+
   /** @description 리뷰 좋아요 추가/삭제 */
   async toggleReviewLike(shortReviewId: number): Promise<void> {
     return post(`/likes`, { shortReviewId });
@@ -77,6 +84,7 @@ export default class ReviewApi {
             cursor: pageParam,
             ...baseParams,
           };
+    // return Promise.reject(new Error("fail"));
     return get<CursorPage<ReviewInfo>>(`/short-reviews/animes/${animeId}`, {
       params,
     });

--- a/src/features/reviews/api/review.ts
+++ b/src/features/reviews/api/review.ts
@@ -84,7 +84,6 @@ export default class ReviewApi {
             cursor: pageParam,
             ...baseParams,
           };
-    // return Promise.reject(new Error("fail"));
     return get<CursorPage<ReviewInfo>>(`/short-reviews/animes/${animeId}`, {
       params,
     });

--- a/src/features/reviews/components/ReviewCard/ReviewComment.style.ts
+++ b/src/features/reviews/components/ReviewCard/ReviewComment.style.ts
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 
-import { TextSize } from "./ReviewComent";
+import { TextSize } from "./ReviewComment";
 
-export const ReviewComentContainer = styled.div<{ textSize: TextSize }>`
+export const ReviewCommentContainer = styled.h1<{ textSize: TextSize }>`
   ${({ theme }) => theme.typo["body-3-r"]}
   ${({ theme }) => theme.colors.neutral[80]}
   display: -webkit-box;

--- a/src/features/reviews/components/ReviewCard/ReviewComment.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewComment.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { ReviewComentContainer } from "./ReviewComent.style";
+import { ReviewCommentContainer } from "./ReviewComment.style";
 import SpoilerComment from "./SpoilerComment";
 
 export type TextSize = "sm" | "md";
@@ -11,7 +11,7 @@ interface ReviewTextProps {
   textSize?: TextSize;
 }
 
-export default function ReviewComent({
+export default function ReviewComment({
   text,
   isSpoiler,
   textSize = "md",
@@ -25,9 +25,9 @@ export default function ReviewComent({
   }, [isSpoiler]);
 
   return (
-    <ReviewComentContainer textSize={textSize}>
+    <ReviewCommentContainer textSize={textSize}>
       {isSpoilerComment && <SpoilerComment onClick={handleShowSpoilerClick} />}
       {!isSpoilerComment && text}
-    </ReviewComentContainer>
+    </ReviewCommentContainer>
   );
 }

--- a/src/features/reviews/components/ReviewCard/ReviewDeleteModal.style.ts
+++ b/src/features/reviews/components/ReviewCard/ReviewDeleteModal.style.ts
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const Text = styled.h1`
+  ${({ theme }) => theme.typo["title-2-m"]}
+  margin: 16px 0;
+  text-align: center;
+`;

--- a/src/features/reviews/components/ReviewCard/ReviewDeleteModal.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewDeleteModal.tsx
@@ -1,5 +1,8 @@
 import Button from "@/components/Button";
 import Modal from "@/components/Modal";
+import useToast from "@/components/Toast/useToast";
+import useReview from "@/features/reviews/hook/useReview";
+import useDebounce from "@/hooks/useDebounce";
 
 import { Text } from "./ReviewDeleteModal.style";
 
@@ -9,11 +12,24 @@ interface Props {
   onClose: () => void;
 }
 
+const DEBOUNCE_DELAY = 200;
+
 export default function ReviewDeleteModal({
   reviewId,
   animeId,
   onClose,
 }: Props) {
+  const { deleteReview } = useReview(animeId, onClose);
+  const { success } = useToast();
+
+  const handleClickDelete = useDebounce(() => {
+    deleteReview.mutate(reviewId, {
+      onSuccess: () => {
+        success({ message: "리뷰가 삭제되었어요." });
+      },
+    });
+  }, DEBOUNCE_DELAY);
+
   return (
     <Modal size="sm" onClose={onClose}>
       <Modal.Content>
@@ -23,7 +39,7 @@ export default function ReviewDeleteModal({
         <Button color="neutral" name="취소" isBlock onClick={onClose}>
           취소
         </Button>
-        <Button color="warn" name="삭제" isBlock>
+        <Button color="warn" name="삭제" isBlock onClick={handleClickDelete}>
           삭제
         </Button>
       </Modal.Actions>

--- a/src/features/reviews/components/ReviewCard/ReviewDeleteModal.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewDeleteModal.tsx
@@ -1,0 +1,32 @@
+import Button from "@/components/Button";
+import Modal from "@/components/Modal";
+
+import { Text } from "./ReviewDeleteModal.style";
+
+interface Props {
+  reviewId: number;
+  animeId: number;
+  onClose: () => void;
+}
+
+export default function ReviewDeleteModal({
+  reviewId,
+  animeId,
+  onClose,
+}: Props) {
+  return (
+    <Modal size="sm" onClose={onClose}>
+      <Modal.Content>
+        <Text>리뷰를 삭제하시겠어요?</Text>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button color="neutral" name="취소" isBlock onClick={onClose}>
+          취소
+        </Button>
+        <Button color="warn" name="삭제" isBlock>
+          삭제
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+}

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
@@ -14,6 +14,7 @@ import useDebounce from "@/hooks/useDebounce";
 import useEvaluation from "../../hook/useEvaluation";
 import ShortReviewModal from "../ReviewRating/ShortReviewModal";
 
+import ReviewDeleteModal from "./ReviewDeleteModal";
 import {
   MoreButton,
   MyRating,
@@ -43,6 +44,7 @@ export default function ReviewMoreButton({
   const { isDropDownModalOpen, handleDropDownModalToggle } = useDropDownModal();
   const snackBar = useSnackBar();
   const [isReviewModalVisible, setIsReviewModalVisible] = useState(false);
+  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
 
   const evaluationMutation = useEvaluation({ animeId });
 
@@ -67,7 +69,10 @@ export default function ReviewMoreButton({
     );
   }, DEBOUNCE_DELAY);
 
-  const handleReviewDeleteClick = () => console.log("리뷰삭제");
+  const handleReviewDeleteClick = () => {
+    handleDropDownModalToggle();
+    setIsDeleteModalVisible(true);
+  };
 
   const handleReviewSpoilerReport = () => {
     handleDropDownModalToggle();
@@ -150,6 +155,14 @@ export default function ReviewMoreButton({
               <Rating size="lg" onRate={handleRate} value={score} />
             </RatingContainer>
           </ShortReviewModal>
+        )}
+
+        {isDeleteModalVisible && (
+          <ReviewDeleteModal
+            reviewId={reviewId}
+            animeId={animeId}
+            onClose={() => setIsDeleteModalVisible(false)}
+          />
         )}
       </AnimatePresence>
     </>

--- a/src/features/reviews/components/ReviewCard/index.tsx
+++ b/src/features/reviews/components/ReviewCard/index.tsx
@@ -4,7 +4,7 @@ import { StrictPropsWithChildren } from "@/types";
 
 import ActionBar from "./ActionBar";
 import Anime from "./Animation";
-import ReviewComent from "./ReviewComent";
+import ReviewComment from "./ReviewComment";
 import { ReviewCardContainer } from "./style";
 import UserRating from "./UserRating";
 
@@ -42,5 +42,5 @@ export default function ReviewCard({
 
 ReviewCard.Anime = Anime;
 ReviewCard.UserRating = UserRating;
-ReviewCard.Comment = ReviewComent;
+ReviewCard.Comment = ReviewComment;
 ReviewCard.ActionBar = ActionBar;

--- a/src/features/reviews/hook/useGetAnimeReviews.ts
+++ b/src/features/reviews/hook/useGetAnimeReviews.ts
@@ -52,6 +52,7 @@ export default function useGetAnimeReviews(animeId: number) {
 
   const {
     data: reviews,
+    isFetchingNextPage,
     fetchNextPage,
     hasNextPage,
     isLoading,
@@ -83,6 +84,7 @@ export default function useGetAnimeReviews(animeId: number) {
   return {
     reviews,
     isLoading,
+    isFetchingNextPage,
     targetRef,
     SORT_OPTION,
     selectedSortOption,


### PR DESCRIPTION
## 📝 개요

로그인 페이지 높이 수정 및 mock api를 이용한 리뷰 삭제 구현

- 로그인 페이지에 생기던 스크롤 제거

<img src="https://github.com/oduck-team/oduck-client/assets/80813703/b9d26413-c125-4842-aed6-8d0c31917d70" width="200px"/>

<br/><br/>

- mock api를 이용한 리뷰 삭제 구현

https://github.com/oduck-team/oduck-client/assets/80813703/d0b21beb-8f58-4797-9937-abd79f1cb93c

<br/>

- 애니 리뷰 목록 ErrorBoundary 적용

<img src="https://github.com/oduck-team/oduck-client/assets/80813703/10198ee5-951d-4dce-8f92-c181354d5a51" width="500px"/>



## 🚀 변경사항

- ReviewComment h1 태그 적용
- 리뷰 목록 ErrorBoundary 적용을 위해 하위 컴포넌트(`Detail/Reviews`)에서 리뷰 목록을 조회하도록 변경

## 🔗 관련 이슈

#347

## ➕ 기타

리뷰 삭제 모달 일단 sm 사이즈로 했는데 사이즈나 그 외 스타일 관련으로 의견 있으시면 말씀해 주세요! 

