### PR TITLE
fix: 프로필 수정 페이지 오류 수정 및 개선

### DIFF
--- a/src/features/users/hooks/useEditForm.tsx
+++ b/src/features/users/hooks/useEditForm.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from "react-router-dom";
 import useToast from "@/components/Toast/useToast";
 import useAuth from "@/features/auth/hooks/useAuth";
 import { useApi } from "@/hooks/useApi";
-import useDebounce from "@/hooks/useDebounce";
 import { fileToWebPFile } from "@/libs/compressor";
 import { useCommonToastError } from "@/libs/error";
 
@@ -66,8 +65,9 @@ export default function useEditForm(name: string, description: string) {
     setIsFormChange(true);
   };
 
-  const handleFormSumbit = useDebounce(async (e: React.FormEvent) => {
+  const handleFormSumbit = async (e: React.FormEvent) => {
     e.preventDefault();
+
     if (!isFormChange || !user) return;
     setIsLoading(true);
 
@@ -122,7 +122,7 @@ export default function useEditForm(name: string, description: string) {
     );
 
     setStatus({ isWarn: false, message: "" });
-  }, 200);
+  };
 
   /** 배경 이미지 및 썸네일 이미지 등록 시, 저장 버튼 활성화 */
   useEffect(() => {

--- a/src/features/users/hooks/useEditForm.tsx
+++ b/src/features/users/hooks/useEditForm.tsx
@@ -62,6 +62,13 @@ export default function useEditForm(name: string, description: string) {
     if (name === "description" && value.length > 100) return;
 
     setForm((prev) => ({ ...prev, [name]: value }));
+
+    if (name === "name" && status.isWarn) {
+      if (isNicknameRegexCheck(value)) {
+        setStatus({ isWarn: false, message: "" });
+      }
+    }
+
     setIsFormChange(true);
   };
 
@@ -77,6 +84,7 @@ export default function useEditForm(name: string, description: string) {
         message:
           "한글, 영문, 숫자만 입력 가능합니다. 한글 또는 영문은 반드시 포함하여 2자~10자 닉네임을 설정해주세요.",
       });
+      setIsLoading(false);
 
       return;
     }

--- a/src/features/users/routes/Edit/EditForm/index.tsx
+++ b/src/features/users/routes/Edit/EditForm/index.tsx
@@ -95,7 +95,7 @@ export default function EditForm({
           <ProfileImageSection.ProfileAvatar>
             <ProfileAvatar.Avatar
               src={previewThumbNail ? previewThumbNail : thumbnail}
-              userName="FE"
+              userName={form.name}
               size="xl"
             />
             <ImageEditButton

--- a/src/features/users/routes/Edit/EditForm/index.tsx
+++ b/src/features/users/routes/Edit/EditForm/index.tsx
@@ -152,6 +152,7 @@ export default function EditForm({
           color={isFormChange ? "primary" : "neutral"}
           isBlock
           size="lg"
+          disabled={isLoading}
           onClick={handleFormSumbit}
         >
           저장
@@ -193,7 +194,6 @@ export default function EditForm({
           onSaveCroppedImage={(file: File) => setCroppedThumbnailImage(file)}
         />
       )}
-      {isLoading && <span>로딩중</span>}
     </EditFormContainer>
   );
 }


### PR DESCRIPTION
## 📝 개요
프로필 수정 페이지 오류 수정 및 개선

## 🚀 변경사항
1. Avatar 컴포넌트의 userName prop 기본값이 'FE'로 고정되어 있는것을 수정
2. form submit 이벤트에 useDebounce hook 적용 시, 엔터를 누르면 페이지가 새로고침되는 현상이 있습니다. 디바운스를 제거하고 button의 disable 속성을 이용해 중복 요청되지 않도록 처리했습니다.
3. 닉네임 정규식 검사 시점을 input change 이벤트에도 추가하여 UX를 개선했습니다.


## 🔗 관련 이슈
#354

## ➕ 기타
issue, PR 템플릿이 적용되지 않고 있는데 설정 확인 부탁드립니다!

