### PR TITLE
feat: 신고하기 UI 제거 및 리뷰 좋아요 버튼 버그 수정

### DIFF
--- a/src/features/reviews/components/ReviewCard/ActionBar.tsx
+++ b/src/features/reviews/components/ReviewCard/ActionBar.tsx
@@ -14,6 +14,7 @@ import ReviewMoreButton from "./ReviewMoreButton";
 
 export interface ActionBarProps {
   isMine: boolean;
+  memberId?: number;
   isLike?: boolean;
   likeCount: number;
   createdAt?: string;
@@ -29,6 +30,7 @@ const DEBOUNCE_DELAY = 200;
 
 export default function ActionBar({
   isMine,
+  memberId,
   isLike,
   likeCount,
   createdAt,
@@ -44,7 +46,12 @@ export default function ActionBar({
   const [isLoginModalVisible, setIsLoginModalVisible] = useState(false);
   const data = useGetIsLike(reviewId);
   const userLike = data ? data.isLike : isLike;
-  const likeMutation = useToggleLike(reviewId, animeId, userLike ?? false);
+  const likeMutation = useToggleLike(
+    reviewId,
+    animeId,
+    userLike ?? false,
+    memberId,
+  );
   const { user } = useAuth();
 
   const handleClickLike = useDebounce(() => {

--- a/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
+++ b/src/features/reviews/components/ReviewCard/ReviewMoreButton.tsx
@@ -5,7 +5,6 @@ import { useState } from "react";
 
 import BackdropPortal from "@/components/Backdrop/BackdropPortal";
 import Rating from "@/components/Rating";
-import useSnackBar from "@/components/SnackBar/useSnackBar";
 import useToast from "@/components/Toast/useToast";
 import DropDownModal from "@/features/users/components/DropDownModal";
 import useDropDownModal from "@/features/users/components/DropDownModal/useDropDownModal";
@@ -42,7 +41,6 @@ export default function ReviewMoreButton({
 }: ReviewMoreButtonProps) {
   const theme = useTheme();
   const { isDropDownModalOpen, handleDropDownModalToggle } = useDropDownModal();
-  const snackBar = useSnackBar();
   const [isReviewModalVisible, setIsReviewModalVisible] = useState(false);
   const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
 
@@ -74,18 +72,6 @@ export default function ReviewMoreButton({
     setIsDeleteModalVisible(true);
   };
 
-  const handleReviewSpoilerReport = () => {
-    handleDropDownModalToggle();
-    snackBar.open({ message: "신고가 접수되었어요." });
-  };
-
-  const handleReviewEtcReport = () => {
-    handleDropDownModalToggle();
-    snackBar.open({
-      message: "신고가 접수되었어요.",
-    });
-  };
-
   const handleBackdropClick = () => {
     if (isDropDownModalOpen) handleDropDownModalToggle();
     if (isReviewModalVisible) handleReviewModalToggle();
@@ -93,78 +79,78 @@ export default function ReviewMoreButton({
 
   return (
     <>
-      <MoreButton
-        name="더보기"
-        icon={<DotsThree color={theme.colors.neutral["50"]} />}
-        variant="text"
-        size="sm"
-        color="neutral"
-        onClick={handleDropDownModalToggle}
-      />
-
-      <AnimatePresence>
-        {(isDropDownModalOpen || isReviewModalVisible) && (
-          <BackdropPortal onClick={handleBackdropClick} />
-        )}
-
-        {isDropDownModalOpen && (
-          <DropDownModal
-            key="DropDownModal"
-            onDropDownModalToggle={handleDropDownModalToggle}
-          >
-            <DropDownModal.Button
-              name={isMine ? "수정하기" : "스포일러 신고"}
-              size="lg"
-              variant="solid"
-              color="neutral"
-              onClick={() =>
-                isMine ? handleReviewEditClick() : handleReviewSpoilerReport()
-              }
-            >
-              {isMine ? "수정하기" : "스포일러 신고"}
-            </DropDownModal.Button>
-            <DropDownModal.Button
-              name={isMine ? "삭제하기" : "기타 신고"}
-              size="lg"
-              variant="solid"
-              color="neutral"
-              onClick={() =>
-                isMine ? handleReviewDeleteClick() : handleReviewEtcReport()
-              }
-            >
-              {isMine ? "삭제하기" : "기타 신고"}
-            </DropDownModal.Button>
-          </DropDownModal>
-        )}
-
-        {isReviewModalVisible && (
-          <ShortReviewModal
-            key="ShortReviewModal"
-            onClose={() => setIsReviewModalVisible(false)}
-            onReview={() => setIsReviewModalVisible(false)}
-            showBackdrop={false}
-            userReviewData={{
-              reviewId,
-              animeId,
-              content,
-              isSpoiler,
-            }}
-          >
-            <MyRating>내 별점</MyRating>
-            <RatingContainer>
-              <Rating size="lg" onRate={handleRate} value={score} />
-            </RatingContainer>
-          </ShortReviewModal>
-        )}
-
-        {isDeleteModalVisible && (
-          <ReviewDeleteModal
-            reviewId={reviewId}
-            animeId={animeId}
-            onClose={() => setIsDeleteModalVisible(false)}
+      {isMine && (
+        <>
+          <MoreButton
+            name="더보기"
+            icon={<DotsThree color={theme.colors.neutral["50"]} />}
+            variant="text"
+            size="sm"
+            color="neutral"
+            onClick={handleDropDownModalToggle}
           />
-        )}
-      </AnimatePresence>
+
+          <AnimatePresence>
+            {(isDropDownModalOpen || isReviewModalVisible) && (
+              <BackdropPortal onClick={handleBackdropClick} />
+            )}
+
+            {isDropDownModalOpen && (
+              <DropDownModal
+                key="DropDownModal"
+                onDropDownModalToggle={handleDropDownModalToggle}
+              >
+                <DropDownModal.Button
+                  name="수정하기"
+                  size="lg"
+                  variant="solid"
+                  color="neutral"
+                  onClick={handleReviewEditClick}
+                >
+                  수정하기
+                </DropDownModal.Button>
+                <DropDownModal.Button
+                  name="삭제하기"
+                  size="lg"
+                  variant="solid"
+                  color="neutral"
+                  onClick={handleReviewDeleteClick}
+                >
+                  삭제하기
+                </DropDownModal.Button>
+              </DropDownModal>
+            )}
+
+            {isReviewModalVisible && (
+              <ShortReviewModal
+                key="ShortReviewModal"
+                onClose={() => setIsReviewModalVisible(false)}
+                onReview={() => setIsReviewModalVisible(false)}
+                showBackdrop={false}
+                userReviewData={{
+                  reviewId,
+                  animeId,
+                  content,
+                  isSpoiler,
+                }}
+              >
+                <MyRating>내 별점</MyRating>
+                <RatingContainer>
+                  <Rating size="lg" onRate={handleRate} value={score} />
+                </RatingContainer>
+              </ShortReviewModal>
+            )}
+
+            {isDeleteModalVisible && (
+              <ReviewDeleteModal
+                reviewId={reviewId}
+                animeId={animeId}
+                onClose={() => setIsDeleteModalVisible(false)}
+              />
+            )}
+          </AnimatePresence>
+        </>
+      )}
     </>
   );
 }

--- a/src/features/reviews/hook/useToggleLike.ts
+++ b/src/features/reviews/hook/useToggleLike.ts
@@ -17,6 +17,7 @@ export default function useToggleLike(
   reviewId: number,
   animeId: number,
   isLike: boolean,
+  memberId?: number, // 다른 사용자 프로필의 memberId
 ) {
   const queryClient = useQueryClient();
   const { reviewApi } = useApi();
@@ -29,7 +30,11 @@ export default function useToggleLike(
     onMutate: async () => {
       // optimistic update를 overwrite하지 않도록 refetch를 cancel
       await queryClient.cancelQueries(["review", animeId, user?.memberId]);
-      await queryClient.cancelQueries(["profile", user?.memberId, "review"]);
+      await queryClient.cancelQueries([
+        "profile",
+        memberId || user?.memberId,
+        "review",
+      ]);
       await queryClient.cancelQueries(["reviewLike", reviewId, user?.memberId]);
       await queryClient.cancelQueries(["MostRecentReviewList"]);
 
@@ -44,7 +49,7 @@ export default function useToggleLike(
         queryClient,
         reviewId,
         isLike,
-        ["profile", user?.memberId, "review"], // 회원 리뷰 목록
+        ["profile", memberId || user?.memberId, "review"], // 회원 리뷰 목록
       );
       const prevRecentReviewList = optimisticUpdateReviews(
         queryClient,
@@ -79,7 +84,7 @@ export default function useToggleLike(
         refetchType: "none", // 사용자의 요청 전까지는 refetch가 일어나지 않도록 합니다.
       });
       queryClient.invalidateQueries({
-        queryKey: ["profile", user?.memberId, "review"],
+        queryKey: ["profile", memberId || user?.memberId, "review"],
         refetchType: "none",
       });
       queryClient.invalidateQueries({
@@ -109,7 +114,7 @@ export default function useToggleLike(
       );
       rollBack(
         queryClient,
-        ["profile", user?.memberId, "review"],
+        ["profile", memberId || user?.memberId, "review"],
         context.prevUserReviewList,
       );
       rollBack(

--- a/src/features/users/components/ProfileImageSection/ProfileSetupButton.tsx
+++ b/src/features/users/components/ProfileImageSection/ProfileSetupButton.tsx
@@ -1,5 +1,4 @@
 import { AnimatePresence } from "framer-motion";
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import BackdropPortal from "@/components/Backdrop/BackdropPortal";
@@ -8,7 +7,6 @@ import useToast from "@/components/Toast/useToast";
 import DropDownModal from "../DropDownModal";
 import useDropDownModal from "../DropDownModal/useDropDownModal";
 
-import ProfileReportModal from "./ProfileReportModal";
 import {
   ProfileSetupButtonContainer,
   Dot,
@@ -25,8 +23,6 @@ export default function ProfileSetupButton({
   userName,
 }: ProfileSetupButtonProps) {
   const { isDropDownModalOpen, handleDropDownModalToggle } = useDropDownModal();
-  const [isReportModalOpen, setIsReportModalOpen] = useState(false);
-  const handleReportModalToggle = () => setIsReportModalOpen((prev) => !prev);
   const navigate = useNavigate();
   const toast = useToast();
   const handleLinkToEditClick = () => navigate("/profile/edit");
@@ -38,13 +34,9 @@ export default function ProfileSetupButton({
         () => toast.error({ message: "링크 복사에 실패했어요." }),
       );
   };
-  const handleReportClick = () => {
-    handleDropDownModalToggle();
-    handleReportModalToggle();
-  };
+
   const handleBackdropClick = () => {
     if (isDropDownModalOpen) handleDropDownModalToggle();
-    if (isReportModalOpen) handleReportModalToggle();
   };
 
   return (
@@ -58,7 +50,7 @@ export default function ProfileSetupButton({
       </ProfileSetupButtonContainer>
 
       <AnimatePresence>
-        {(isDropDownModalOpen || isReportModalOpen) && (
+        {isDropDownModalOpen && (
           <BackdropPortal onClick={handleBackdropClick} />
         )}
 
@@ -76,25 +68,18 @@ export default function ProfileSetupButton({
             >
               프로필 링크 복사
             </DropDownModal.Button>
-            <DropDownModal.Button
-              name={isMine ? "프로필 수정" : "신고하기"}
-              size="lg"
-              variant="solid"
-              color="neutral"
-              onClick={() =>
-                isMine ? handleLinkToEditClick() : handleReportClick()
-              }
-            >
-              {isMine ? "프로필 수정" : "신고하기"}
-            </DropDownModal.Button>
+            {isMine && (
+              <DropDownModal.Button
+                name="프로필 수정"
+                size="lg"
+                variant="solid"
+                color="neutral"
+                onClick={handleLinkToEditClick}
+              >
+                프로필 수정
+              </DropDownModal.Button>
+            )}
           </DropDownModal>
-        )}
-
-        {isReportModalOpen && (
-          <ProfileReportModal
-            key="ProfileReportModal"
-            onClose={handleReportModalToggle}
-          />
         )}
       </AnimatePresence>
     </>

--- a/src/features/users/components/ProfileImageSection/tests/ProfileSetupButton.test.tsx
+++ b/src/features/users/components/ProfileImageSection/tests/ProfileSetupButton.test.tsx
@@ -62,24 +62,4 @@ describe("ProfileSetupButton", () => {
       expect(screen.getByText("프로필 수정 페이지")).toBeInTheDocument();
     });
   });
-
-  it("다른 사용자의 프로필 설정 버튼 클릭하면, '신고하기' 버튼이 렌더링 된다.", () => {
-    customRender(
-      <MemoryRouter>
-        <ProfileImageSection>
-          <ProfileImageSection.ProfileSetupButton
-            isMine={false}
-            userName="testUser"
-          />
-        </ProfileImageSection>
-      </MemoryRouter>,
-    );
-
-    const button = screen.getByRole("button");
-    fireEvent.click(button);
-
-    const reportButton = screen.getByLabelText("신고하기");
-
-    expect(reportButton).toBeInTheDocument();
-  });
 });

--- a/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
+++ b/src/features/users/routes/Profile/TabMenu/ReviewList.tsx
@@ -6,12 +6,14 @@ import EmptyList from "./EmptyList";
 
 interface ReviewListProps {
   isMine: boolean;
+  memberId: number;
   list: ReviewListResponse[];
   isLoading: boolean;
 }
 
 export default function ReviewList({
   isMine,
+  memberId,
   list,
   isLoading,
 }: ReviewListProps) {
@@ -54,6 +56,7 @@ export default function ReviewList({
             createdAt={review.createdAt}
             isTimeAgo={false}
             isMine={isMine}
+            memberId={memberId}
             likeCount={review.likeCount}
             reviewId={review.reviewId}
             animeId={review.animeId}

--- a/src/features/users/routes/Profile/TabMenu/index.tsx
+++ b/src/features/users/routes/Profile/TabMenu/index.tsx
@@ -62,6 +62,7 @@ export default function TabMenu({ isMine, memberId }: TabMenuProps) {
         {selectedMenu === "한줄리뷰" && (
           <ReviewList
             isMine={isMine}
+            memberId={memberId}
             list={reviews?.pages ?? []}
             isLoading={isLoadingReview}
           />


### PR DESCRIPTION
## 📝 개요
- 신고하기 버튼 UI 제거
- 리뷰 좋아요 버튼 버그 수정

## 🚀 변경사항
- 신고하기 버튼 UI 제거

| 내 프로필 | 다른 사용자 프로필 |
| ---- | ---- |
| ![image](https://github.com/oduck-team/oduck-client/assets/115006670/3d4f83ba-9498-4ea6-bedf-5175bba22c36) | ![image](https://github.com/oduck-team/oduck-client/assets/115006670/fc0a4b39-7f5b-41cd-b892-1085b605f9cd) |

- 내 리뷰인 경우에만 더보기 버튼 렌더링

| 리뷰 더보기 버튼 | 
| ---- |
| ![image](https://github.com/oduck-team/oduck-client/assets/115006670/778edb15-ef75-4203-9229-375ecb5cfd8e) |

- 리뷰 좋아요 버튼 버그 수정
   - 다른 사용자 프로필 페이지에서 좋아요 버튼 토글 시, review count가 변경되지 않고 있었습니다.
   - `useToggleLike.ts`의 프로필 페이지 관련 queryKey가 로그인 사용자의 memberId만 설정되어 있어서 버그 발생
   - queryKey에 다른 사용자의 memberId도 추가하여 문제 해결 



## 🔗 관련 이슈
#366

## ➕ 기타


